### PR TITLE
test: 특정 유저 팔로워 조회

### DIFF
--- a/src/test/java/com/flab/readnshare/domain/follow/controller/FollowApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/controller/FollowApiControllerTest.java
@@ -1,0 +1,57 @@
+package com.flab.readnshare.domain.follow.controller;
+
+import com.flab.readnshare.domain.follow.facade.FollowFacade;
+import com.flab.readnshare.domain.member.dto.MemberResponseDto;
+import com.flab.readnshare.global.config.WebMvcConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = FollowApiController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = WebMvcConfig.class
+        )
+)
+@MockBean(JpaMetamodelMappingContext.class)
+class FollowApiControllerTest {
+
+    @MockBean
+    FollowFacade followFacade;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @DisplayName("특정 유저의 팔로워 목록을 조회한다.")
+    @Test
+    void followersOf() throws Exception {
+        // Given
+        List<MemberResponseDto> result = List.of();
+        BDDMockito.given(followFacade.getFollowersOf(anyString()))
+                .willReturn(result);
+
+        // When
+        // Then
+        mockMvc
+                .perform(
+                        get("/api/follow/followers/{memberEmail}", "test")
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/flab/readnshare/domain/follow/facade/FollowFacadeTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/facade/FollowFacadeTest.java
@@ -5,8 +5,10 @@ import com.flab.readnshare.domain.follow.domain.Follow;
 import com.flab.readnshare.domain.follow.event.FollowEvent;
 import com.flab.readnshare.domain.follow.service.FollowService;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.service.MemberService;
 import com.flab.readnshare.global.common.exception.FollowException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,10 +17,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class FollowFacadeTest {
@@ -87,4 +91,33 @@ class FollowFacadeTest {
         // then
         verify(followService, times(1)).delete(fromMember, toMember);
     }
+
+    @DisplayName("특정 유저의 팔로우 목록을 조회한다.")
+    @Test
+    void getFollowersOf() throws Exception {
+        // Given
+        Member toMember = FollowTestFixture.getMemberEntity();
+        Member fromMember1 = FollowTestFixture.getMemberEntity();
+        Member fromMember2 = FollowTestFixture.getMemberEntity();
+        Follow follow1 = FollowTestFixture.getFollowEntity(fromMember1, toMember);
+        Follow follow2 = FollowTestFixture.getFollowEntity(fromMember2, toMember);
+
+        String memberEmail = toMember.getEmail();
+        given(memberService.findByEmail(eq(memberEmail)))
+                .willReturn(toMember);
+        given(followService.getFollowers(eq(toMember)))
+                .willReturn(List.of(follow1, follow2));
+
+        // When
+        List<MemberResponseDto> followers = followFacade.getFollowersOf(memberEmail);
+
+        // Then
+        Assertions.assertThat(followers).hasSize(2)
+                .extracting("email")
+                .containsExactlyInAnyOrder(
+                        fromMember1.getEmail(),
+                        fromMember2.getEmail()
+                );
+    }
+
 }

--- a/src/test/java/com/flab/readnshare/domain/follow/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/repository/FollowRepositoryTest.java
@@ -1,0 +1,77 @@
+package com.flab.readnshare.domain.follow.repository;
+
+import com.flab.readnshare.domain.follow.domain.Follow;
+import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class FollowRepositoryTest {
+
+    @Autowired
+    FollowRepository followRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        followRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("특정 유저의 팔로우 목록을 조회한다.")
+    @Test
+    void findByToMember() throws Exception {
+        // Given
+        List<Member> members = createMembers();
+        memberRepository.saveAll(members);
+        List<Member> findMembers = memberRepository.findAll();
+        Member toMember = createFollows(findMembers);
+
+        // When
+        List<Follow> follows = followRepository.findByToMember(toMember);
+
+        // Then
+        assertThat(follows).hasSize(2)
+                .extracting("fromMember.nickName")
+                .containsExactlyInAnyOrder("test2", "test3");
+    }
+
+    private List<Member> createMembers() {
+        Member member1 = createMember("test1");
+        Member member2 = createMember("test2");
+        Member member3 = createMember("test3");
+        List<Member> members = List.of(member1, member2, member3);
+        return members;
+    }
+
+    private Member createMember(String nickName) {
+        return Member.builder()
+                .email("test")
+                .password(null)
+                .nickName(nickName)
+                .build();
+    }
+
+    private Member createFollows(List<Member> findMembers) {
+        Member toMember = findMembers.getFirst();
+        for (int i = 1; i < findMembers.size(); i++) {
+            Follow follow = Follow.builder()
+                    .fromMember(findMembers.get(i))
+                    .toMember(toMember)
+                    .build();
+            followRepository.save(follow);
+        }
+        return toMember;
+    }
+
+}

--- a/src/test/java/com/flab/readnshare/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/service/FollowServiceTest.java
@@ -5,6 +5,7 @@ import com.flab.readnshare.domain.follow.domain.Follow;
 import com.flab.readnshare.domain.follow.repository.FollowRepository;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.global.common.exception.FollowException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,9 +13,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +42,31 @@ class FollowServiceTest {
         // when & then
         assertThrows(FollowException.DuplicateFollowException.class, () ->
                 followService.save(fromMember, toMember));
+    }
+
+    @DisplayName("특정 사용자의 팔로우 목록을 조회한다.")
+    @Test
+    void getFollowers() throws Exception {
+        // Given
+        Member toMember = FollowTestFixture.getMemberEntity();
+        Member fromMember1 = FollowTestFixture.getMemberEntity();
+        Member fromMember2 = FollowTestFixture.getMemberEntity();
+        Follow follow1 = FollowTestFixture.getFollowEntity(fromMember1, toMember);
+        Follow follow2 = FollowTestFixture.getFollowEntity(fromMember2, toMember);
+
+        given(followRepository.findByToMember(eq(toMember)))
+                .willReturn(List.of(follow1, follow2));
+
+        // When
+        List<Follow> followers = followService.getFollowers(toMember);
+
+        // Then
+        Assertions.assertThat(followers).hasSize(2)
+                .extracting("fromMember")
+                .containsExactlyInAnyOrder(
+                        fromMember1,
+                        fromMember2
+                );
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #18, #28

## 📝 작업 내용

> 특정 유저 팔로워 조회 테스트 코드 추가
> JwtAuthInterceptor를 피하기 위해 WebMvcConfig exclude
> JPA 메타 모델 만들기 위해 @MockBean(JpaMetamodelMappingContext.class) 추가

### 스크린샷 (선택)
![스크린샷 2025-03-17 오후 6 47 46](https://github.com/user-attachments/assets/de7048a1-402a-4b5e-8dc0-d256750cdb5c)

## 💬 리뷰 요구사항(선택)

> JwtAuthInterceptor의 Component 어노테이션 , ReadnshareApplication의 EnableJpaAuditing 어노테이션에 대한 처리가 필요합니다.
