### PR TITLE
feat: 특정 유저의 팔로우, 팔로잉 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/follow/controller/FollowApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/follow/controller/FollowApiController.java
@@ -2,11 +2,14 @@ package com.flab.readnshare.domain.follow.controller;
 
 import com.flab.readnshare.domain.follow.facade.FollowFacade;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.global.common.resolver.SignInMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +31,11 @@ public class FollowApiController {
             , @SignInMember Member fromMember) {
         followFacade.unfollow(memberEmail, fromMember);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/followers/{memberEmail}")
+    public ResponseEntity<List<MemberResponseDto>> followersOf(@PathVariable String memberEmail) {
+        List<MemberResponseDto> followers = followFacade.getFollowersOf(memberEmail);
+        return new ResponseEntity<>(followers, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/follow/controller/FollowApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/follow/controller/FollowApiController.java
@@ -38,4 +38,10 @@ public class FollowApiController {
         List<MemberResponseDto> followers = followFacade.getFollowersOf(memberEmail);
         return new ResponseEntity<>(followers, HttpStatus.OK);
     }
+
+    @GetMapping("/followings/{memberEmail}")
+    public ResponseEntity<List<MemberResponseDto>> followingsOf(@PathVariable String memberEmail) {
+        List<MemberResponseDto> followings = followFacade.getFollowingsOf(memberEmail);
+        return new ResponseEntity<>(followings, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/flab/readnshare/domain/follow/facade/FollowFacade.java
+++ b/src/main/java/com/flab/readnshare/domain/follow/facade/FollowFacade.java
@@ -4,12 +4,15 @@ import com.flab.readnshare.domain.follow.domain.Follow;
 import com.flab.readnshare.domain.follow.event.FollowEvent;
 import com.flab.readnshare.domain.follow.service.FollowService;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.service.MemberService;
 import com.flab.readnshare.global.common.exception.FollowException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +42,20 @@ public class FollowFacade {
         Member toMember = memberService.findByEmail(memberEmail);
 
         followService.delete(fromMember, toMember);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberResponseDto> getFollowersOf(String memberEmail) {
+        Member toMember = memberService.findByEmail(memberEmail);
+
+        List<Follow> followers = followService.getFollowers(toMember);
+        return followers.stream()
+                .map(follow -> follow.getFromMember())
+                .map(member -> MemberResponseDto.builder()
+                        .id(member.getId())
+                        .email(member.getEmail())
+                        .nickName(member.getNickName())
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/follow/facade/FollowFacade.java
+++ b/src/main/java/com/flab/readnshare/domain/follow/facade/FollowFacade.java
@@ -58,4 +58,18 @@ public class FollowFacade {
                         .build())
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public List<MemberResponseDto> getFollowingsOf(String memberEmail) {
+        Member fromMember = memberService.findByEmail(memberEmail);
+        List<Follow> followings = followService.getFollowings(fromMember);
+        return followings.stream()
+                .map(following -> following.getToMember())
+                .map(member -> MemberResponseDto.builder()
+                        .id(member.getId())
+                        .email(member.getEmail())
+                        .nickName(member.getNickName())
+                        .build())
+                .toList();
+    }
 }

--- a/src/main/java/com/flab/readnshare/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/flab/readnshare/domain/follow/repository/FollowRepository.java
@@ -11,4 +11,6 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFromMemberAndToMember(Member fromMember, Member toMember);
 
     List<Follow> findByToMember(Member member);
+
+    List<Follow> findByFromMember(Member member);
 }

--- a/src/main/java/com/flab/readnshare/domain/follow/service/FollowService.java
+++ b/src/main/java/com/flab/readnshare/domain/follow/service/FollowService.java
@@ -48,4 +48,8 @@ public class FollowService {
     public List<Follow> getFollowers(Member member) {
         return followRepository.findByToMember(member);
     }
+
+    public List<Follow> getFollowings(Member member) {
+        return followRepository.findByFromMember(member);
+    }
 }

--- a/src/main/java/com/flab/readnshare/domain/follow/service/FollowService.java
+++ b/src/main/java/com/flab/readnshare/domain/follow/service/FollowService.java
@@ -44,4 +44,8 @@ public class FollowService {
                 .map(follow -> follow.getFromMember().getId())
                 .toList();
     }
+
+    public List<Follow> getFollowers(Member member) {
+        return followRepository.findByToMember(member);
+    }
 }

--- a/src/test/java/com/flab/readnshare/domain/follow/controller/FollowApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/controller/FollowApiControllerTest.java
@@ -54,4 +54,22 @@ class FollowApiControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk());
     }
+
+    @DisplayName("특정 유저의 팔로잉 목록을 조회한다.")
+    @Test
+    void followingsOf() throws Exception {
+        // Given
+        List<MemberResponseDto> result = List.of();
+        BDDMockito.given(followFacade.getFollowingsOf(anyString()))
+                .willReturn(result);
+
+        // When
+        // Then
+        mockMvc
+                .perform(
+                        get("/api/follow/followings/{memberEmail}", "test")
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/flab/readnshare/domain/follow/controller/FollowApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/controller/FollowApiControllerTest.java
@@ -1,0 +1,57 @@
+package com.flab.readnshare.domain.follow.controller;
+
+import com.flab.readnshare.domain.follow.facade.FollowFacade;
+import com.flab.readnshare.domain.member.dto.MemberResponseDto;
+import com.flab.readnshare.global.config.WebMvcConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = FollowApiController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = WebMvcConfig.class
+        )
+)
+@MockBean(JpaMetamodelMappingContext.class)
+class FollowApiControllerTest {
+
+    @MockBean
+    FollowFacade followFacade;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @DisplayName("특정 유저의 팔로워 목록을 조회한다.")
+    @Test
+    void followersOf() throws Exception {
+        // Given
+        List<MemberResponseDto> result = List.of();
+        BDDMockito.given(followFacade.getFollowersOf(anyString()))
+                .willReturn(result);
+
+        // When
+        // Then
+        mockMvc
+                .perform(
+                        get("/api/follow/followers/{memberEmail}", "test")
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/flab/readnshare/domain/follow/facade/FollowFacadeTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/facade/FollowFacadeTest.java
@@ -120,4 +120,32 @@ class FollowFacadeTest {
                 );
     }
 
+    @DisplayName("특정 유저의 팔로잉 목록을 조회한다.")
+    @Test
+    void getFollowingsOf() throws Exception {
+        // Given
+        Member fromMember = FollowTestFixture.getMemberEntity();
+        Member toMember1 = FollowTestFixture.getMemberEntity();
+        Member toMember2 = FollowTestFixture.getMemberEntity();
+        Follow follow1 = FollowTestFixture.getFollowEntity(fromMember, toMember1);
+        Follow follow2 = FollowTestFixture.getFollowEntity(fromMember, toMember2);
+
+        String memberEmail = fromMember.getEmail();
+        given(memberService.findByEmail(eq(memberEmail)))
+                .willReturn(fromMember);
+        given(followService.getFollowings(eq(fromMember)))
+                .willReturn(List.of(follow1, follow2));
+
+        // When
+        List<MemberResponseDto> followings = followFacade.getFollowingsOf(memberEmail);
+
+        // Then
+        Assertions.assertThat(followings).hasSize(2)
+                .extracting("email")
+                .containsExactlyInAnyOrder(
+                        toMember1.getEmail(),
+                        toMember2.getEmail()
+                );
+    }
+
 }

--- a/src/test/java/com/flab/readnshare/domain/follow/facade/FollowFacadeTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/facade/FollowFacadeTest.java
@@ -5,8 +5,10 @@ import com.flab.readnshare.domain.follow.domain.Follow;
 import com.flab.readnshare.domain.follow.event.FollowEvent;
 import com.flab.readnshare.domain.follow.service.FollowService;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.service.MemberService;
 import com.flab.readnshare.global.common.exception.FollowException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,10 +17,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class FollowFacadeTest {
@@ -87,4 +91,33 @@ class FollowFacadeTest {
         // then
         verify(followService, times(1)).delete(fromMember, toMember);
     }
+
+    @DisplayName("특정 유저의 팔로우 목록을 조회한다.")
+    @Test
+    void getFollowersOf() throws Exception {
+        // Given
+        Member toMember = FollowTestFixture.getMemberEntity();
+        Member fromMember1 = FollowTestFixture.getMemberEntity();
+        Member fromMember2 = FollowTestFixture.getMemberEntity();
+        Follow follow1 = FollowTestFixture.getFollowEntity(fromMember1, toMember);
+        Follow follow2 = FollowTestFixture.getFollowEntity(fromMember2, toMember);
+
+        String memberEmail = toMember.getEmail();
+        given(memberService.findByEmail(eq(memberEmail)))
+                .willReturn(toMember);
+        given(followService.getFollowers(eq(toMember)))
+                .willReturn(List.of(follow1, follow2));
+
+        // When
+        List<MemberResponseDto> followers = followFacade.getFollowersOf(memberEmail);
+
+        // Then
+        Assertions.assertThat(followers).hasSize(2)
+                .extracting("email")
+                .containsExactlyInAnyOrder(
+                        fromMember1.getEmail(),
+                        fromMember2.getEmail()
+                );
+    }
+
 }

--- a/src/test/java/com/flab/readnshare/domain/follow/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/repository/FollowRepositoryTest.java
@@ -46,6 +46,24 @@ class FollowRepositoryTest {
                 .containsExactlyInAnyOrder("test2", "test3");
     }
 
+    @DisplayName("특정 유저의 팔로잉 목록을 조회한다.")
+    @Test
+    void findByFromMember() throws Exception {
+        // Given
+        List<Member> members = createMembers();
+        memberRepository.saveAll(members);
+        List<Member> findMembers = memberRepository.findAll();
+        Member fromMember = createFollowings(findMembers);
+
+        // When
+        List<Follow> follows = followRepository.findByFromMember(fromMember);
+
+        // Then
+        assertThat(follows).hasSize(2)
+                .extracting("toMember.nickName")
+                .containsExactlyInAnyOrder("test2", "test3");
+    }
+
     private List<Member> createMembers() {
         Member member1 = createMember("test1");
         Member member2 = createMember("test2");
@@ -72,6 +90,18 @@ class FollowRepositoryTest {
             followRepository.save(follow);
         }
         return toMember;
+    }
+
+    private Member createFollowings(List<Member> findMembers) {
+        Member fromMember = findMembers.getFirst();
+        for (int i = 1; i < findMembers.size(); i++) {
+            Follow follow = Follow.builder()
+                    .fromMember(fromMember)
+                    .toMember(findMembers.get(i))
+                    .build();
+            followRepository.save(follow);
+        }
+        return fromMember;
     }
 
 }

--- a/src/test/java/com/flab/readnshare/domain/follow/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/repository/FollowRepositoryTest.java
@@ -1,0 +1,77 @@
+package com.flab.readnshare.domain.follow.repository;
+
+import com.flab.readnshare.domain.follow.domain.Follow;
+import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class FollowRepositoryTest {
+
+    @Autowired
+    FollowRepository followRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @AfterEach
+    void tearDown() {
+        followRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("특정 유저의 팔로우 목록을 조회한다.")
+    @Test
+    void findByToMember() throws Exception {
+        // Given
+        List<Member> members = createMembers();
+        memberRepository.saveAll(members);
+        List<Member> findMembers = memberRepository.findAll();
+        Member toMember = createFollows(findMembers);
+
+        // When
+        List<Follow> follows = followRepository.findByToMember(toMember);
+
+        // Then
+        assertThat(follows).hasSize(2)
+                .extracting("fromMember.nickName")
+                .containsExactlyInAnyOrder("test2", "test3");
+    }
+
+    private List<Member> createMembers() {
+        Member member1 = createMember("test1");
+        Member member2 = createMember("test2");
+        Member member3 = createMember("test3");
+        List<Member> members = List.of(member1, member2, member3);
+        return members;
+    }
+
+    private Member createMember(String nickName) {
+        return Member.builder()
+                .email("test")
+                .password(null)
+                .nickName(nickName)
+                .build();
+    }
+
+    private Member createFollows(List<Member> findMembers) {
+        Member toMember = findMembers.getFirst();
+        for (int i = 1; i < findMembers.size(); i++) {
+            Follow follow = Follow.builder()
+                    .fromMember(findMembers.get(i))
+                    .toMember(toMember)
+                    .build();
+            followRepository.save(follow);
+        }
+        return toMember;
+    }
+
+}

--- a/src/test/java/com/flab/readnshare/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/service/FollowServiceTest.java
@@ -69,4 +69,29 @@ class FollowServiceTest {
                 );
     }
 
+    @DisplayName("특정 사용자의 팔로잉 목록을 조회한다.")
+    @Test
+    void getFollowings() throws Exception {
+        // Given
+        Member fromMember = FollowTestFixture.getMemberEntity();
+        Member toMember1 = FollowTestFixture.getMemberEntity();
+        Member toMember2 = FollowTestFixture.getMemberEntity();
+        Follow follow1 = FollowTestFixture.getFollowEntity(fromMember, toMember1);
+        Follow follow2 = FollowTestFixture.getFollowEntity(fromMember, toMember2);
+
+        given(followRepository.findByFromMember(eq(fromMember)))
+                .willReturn(List.of(follow1, follow2));
+
+        // When
+        List<Follow> followers = followService.getFollowings(fromMember);
+
+        // Then
+        Assertions.assertThat(followers).hasSize(2)
+                .extracting("toMember")
+                .containsExactlyInAnyOrder(
+                        toMember1,
+                        toMember2
+                );
+    }
+
 }

--- a/src/test/java/com/flab/readnshare/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/service/FollowServiceTest.java
@@ -5,6 +5,7 @@ import com.flab.readnshare.domain.follow.domain.Follow;
 import com.flab.readnshare.domain.follow.repository.FollowRepository;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.global.common.exception.FollowException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,9 +13,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +42,31 @@ class FollowServiceTest {
         // when & then
         assertThrows(FollowException.DuplicateFollowException.class, () ->
                 followService.save(fromMember, toMember));
+    }
+
+    @DisplayName("특정 사용자의 팔로우 목록을 조회한다.")
+    @Test
+    void getFollowers() throws Exception {
+        // Given
+        Member toMember = FollowTestFixture.getMemberEntity();
+        Member fromMember1 = FollowTestFixture.getMemberEntity();
+        Member fromMember2 = FollowTestFixture.getMemberEntity();
+        Follow follow1 = FollowTestFixture.getFollowEntity(fromMember1, toMember);
+        Follow follow2 = FollowTestFixture.getFollowEntity(fromMember2, toMember);
+
+        given(followRepository.findByToMember(eq(toMember)))
+                .willReturn(List.of(follow1, follow2));
+
+        // When
+        List<Follow> followers = followService.getFollowers(toMember);
+
+        // Then
+        Assertions.assertThat(followers).hasSize(2)
+                .extracting("fromMember")
+                .containsExactlyInAnyOrder(
+                        fromMember1,
+                        fromMember2
+                );
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #19, #28, #35, #37

## 📝 작업 내용

> 특정 유저의 팔로우 목록 조회하기
> 특정 유저의 팔로잉 목록 조회하기
> 특정 유저의 팔로우 목록 조회 테스트 코드 작성하기
> 특정 유저의 팔로잉 목록 조회 테스트 코드 작성하기
> 발생하는 버그 및 에러 파악 후 문서화하기
>> [팔로워 목록 조회시 N + 1 쿼리 문제](https://www.notion.so/goormkdx/N-1-1b9c0ff4ce3180b898f1d3c82b7daa60)
>> [@WebMvcTest시 발생하는 예외](https://www.notion.so/goormkdx/WebMvcTest-1b9c0ff4ce3180bcbb80c4d823ddef2a)
>> [입력 파라미터 값 검증](https://www.notion.so/goormkdx/1b9c0ff4ce31802cb789c246936bda02)
>> [@WebMvcTest vs standaloneSetup](https://www.notion.so/goormkdx/WebMvcTest-vs-standaloneSetup-1b9c0ff4ce31801fbd60c864e0c473eb)

### 스크린샷 (선택)
![스크린샷 2025-03-17 오후 3 02 37](https://github.com/user-attachments/assets/ef554aaf-2c37-4b2e-b51f-e08777ff5919)
![스크린샷 2025-03-17 오후 6 47 46](https://github.com/user-attachments/assets/d74be7e7-8710-4617-822f-d2c0cff37dea)
![스크린샷 2025-03-17 오후 7 20 30](https://github.com/user-attachments/assets/f2d8eaa1-4365-4698-8942-51bf15abf5e6)
![스크린샷 2025-03-17 오후 8 13 46](https://github.com/user-attachments/assets/fbbc1989-f84a-474a-9833-8e0f9dad957b)

## 💬 리뷰 요구사항(선택)

> 각 커밋의 커밋메시지를 읽어주세요.
