### PR TITLE
Feat: #22 사용자 정보 수정 테스트코드 추가

### DIFF
--- a/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
@@ -2,6 +2,7 @@ package com.flab.readnshare.domain.member.controller;
 
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
+import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
 import com.flab.readnshare.domain.member.service.MemberService;
 import com.flab.readnshare.global.common.advice.ApiExceptionAdvice;
 import com.flab.readnshare.global.common.exception.MemberException;
@@ -147,4 +148,81 @@ class MemberApiControllerTest {
         ;
     }
 
+    @Test
+    @DisplayName("회원수정에 성공한다.")
+    void update_success() throws Exception {
+        // given
+        UpdateRequestDto request = UpdateRequestDto.builder()
+                .password("test24680!")
+                .nickName("test")
+                .build();
+
+        given(memberService.update(any(Long.class), any(UpdateRequestDto.class)))
+                .willReturn(MemberResponseDto.builder()
+                        .id(1L)
+                        .email("test@naver.com")
+                        .nickName("test")
+                        .build().toEntity());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.put("/api/member/1") // PUT 메서드로 변경
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new Gson().toJson(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("test@naver.com")) // 기존 이메일
+                .andExpect(jsonPath("$.nickName").value(request.getNickName())); // 변경된 닉네임
+
+    }
+
+    @Test
+    @DisplayName("회원수정에 실패한다.(비밀번호)")
+    void update_fail_password_format() throws Exception {
+        // given
+        UpdateRequestDto request = UpdateRequestDto.builder()
+                .password("123")
+                .nickName("test")
+                .build();
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.put("/api/member/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new Gson().toJson(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("입력값을 확인하세요."))
+                .andExpect(jsonPath("$.errors[0].field").value("password"))
+                .andExpect(jsonPath("$.errors[0].message").value("비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요."))
+        ;
+    }
+
+    @Test
+    @DisplayName("회원수정에 실패한다.(닉네임 없음)")
+    void update_fail_nickName_format() throws Exception {
+        // given
+        UpdateRequestDto request = UpdateRequestDto.builder()
+                .password("test24680!")
+                .nickName("")
+                .build();
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.put("/api/member/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new Gson().toJson(request))
+        );
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("입력값을 확인하세요."))
+                .andExpect(jsonPath("$.errors[0].field").value("nickName"))
+                .andExpect(jsonPath("$.errors[0].message").value("닉네임을 입력해주세요."))
+        ;
+    }
 }

--- a/src/test/java/com/flab/readnshare/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.flab.readnshare.domain.member.service;
 
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
+import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
 import com.flab.readnshare.domain.member.repository.MemberRepository;
 import com.flab.readnshare.global.common.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
@@ -69,5 +70,37 @@ class MemberServiceTest {
 
         // then
         assertThrows(MemberException.DuplicateEmailException.class, () -> memberService.signUp(request),"이메일이 중복되어 회원가입에 실패해야 합니다.");
+    }
+
+    @Test
+    @DisplayName("회원 정보를 수정하면 성공적으로 업데이트된다.")
+    void update_success_member() {
+        // given (기존 회원 정보)
+        Long memberId = 1L;
+        Member existingMember = Member.builder()
+                .id(memberId)
+                .email("test@naver.com")  // 기본 이메일은 수정하지 않음
+                .password("oldPassword123!")
+                .nickName("oldNickName")
+                .build();
+
+        UpdateRequestDto request = UpdateRequestDto.builder()
+                .password("newPassword24680!") // 새로운 비밀번호
+                .nickName("newNickName")       // 새로운 닉네임
+                .build();
+
+        // 기존 회원이 존재하는 경우를 가정
+        // findById()로 given으로 주어진 existingMember를 반환
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(existingMember));
+
+        // update()는 void이므로 doNothing() 사용
+        // update()를 사용하였을 때 예외처리 안하도록 설정하는 코드
+        doNothing().when(memberRepository).update(memberId, request.getNickName(), request.getPassword());
+
+        // when (실제 메소드를 불러와 회원정보 수정)
+        memberService.update(memberId, request);
+
+        // then (update가 딱 한번 잘 호출했는지 확인: times)
+        verify(memberRepository, times(1)).update(memberId, request.getNickName(), request.getPassword());
     }
 }


### PR DESCRIPTION
- controller test case 1) 회원수정 성공 2) 비밀번호 변경 실패 3) 닉네임 없음
- service test case 1) 회원정보 수정 성공

Resolves: #22

## #️⃣ 연관된 이슈

> #22

## 📝 작업 내용
>![image](https://github.com/user-attachments/assets/0ab6e2fe-86d2-43bf-a994-23ac1ac6d368)
>![image](https://github.com/user-attachments/assets/a76ea29f-70ea-4dd2-af8e-24fddf65ab41)
>![image](https://github.com/user-attachments/assets/37076120-b11a-4364-b99e-4d4b0a51ddf5)
>![image](https://github.com/user-attachments/assets/30a2dab4-ed59-463e-a626-612d38c87e78)

## 💬 리뷰 요구사항(선택)
> 테스트케이스를 더 추가해야할지..
> service의 경우 실패케이스를 만들기 힘들었습니다.
