### PR TITLE
refactor: 본인 확인 메서드의 조건절 수정

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/review/domain/Review.java
+++ b/src/main/java/com/flab/readnshare/domain/review/domain/Review.java
@@ -43,8 +43,19 @@ public class Review extends BaseTimeEntity {
         this.book = book;
     }
 
+    // [2025.3.17 코멘트]
+    // 기존 코드에서 if 절의 조건인 this.member != member보다 equals를 오버라이딩하는게 맞지 않은가 싶음.
+    // PK만 동일하다면 객체가 달라도 동일인으로 볼 수 있지 않은가?
+
+//  <기존 코드>
+//    public void verifyMember(Member member) {
+//        if (this.member != member) {
+//            throw new ReviewException.ForbiddenMemberException();
+//        }
+//    }
+
     public void verifyMember(Member member) {
-        if (this.member != member) {
+        if (!this.member.equals(member)) {
             throw new ReviewException.ForbiddenMemberException();
         }
     }


### PR DESCRIPTION
객체의 비교가 아닌 PK의 비교가 중요하므로 비교연산자에서 equals로 조건절
처리 변경

Resolved: #33

## #️⃣ 연관된 이슈

> #33  

## 📝 작업 내용

> 기존의 CRUD 테스트코드는 돌려보았고 문제는 없었습니다.

### 스크린샷 (선택)

![스크린샷 2025-03-18 101611](https://github.com/user-attachments/assets/9b560505-f4bd-4bbb-8dc5-424a38815cd3)

## 💬 리뷰 요구사항(선택)

> 
>
> 
