### PR TITLE
feat: 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
@@ -34,4 +31,14 @@ public class MemberApiController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<Void> delete(@PathVariable Long memberId) {
+        // 회원이 없을 경우
+        if (memberService.findById(memberId) == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        memberService.delete(memberId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/flab/readnshare/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/flab/readnshare/domain/member/repository/MemberRepository.java
@@ -2,9 +2,15 @@ package com.flab.readnshare.domain.member.repository;
 
 import com.flab.readnshare.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+
+    @Modifying
+    @Query("DELETE FROM Member m WHERE m.id = :memberId")
+    void deleteById(Long memberId);
 }

--- a/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
@@ -34,4 +34,12 @@ public class MemberService {
                 .orElseThrow(MemberException.MemberNotFoundException::new);
     }
 
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberException.MemberNotFoundException::new);
+    }
+
+    public void delete(Long memberId) {
+        memberRepository.deleteById(memberId);
+    }
 }

--- a/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
@@ -1,5 +1,6 @@
 package com.flab.readnshare.domain.member.controller;
 
+import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.service.MemberService;
@@ -20,6 +21,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -145,6 +147,50 @@ class MemberApiControllerTest {
                 .andExpect(jsonPath("$.errors[0].field").value("password"))
                 .andExpect(jsonPath("$.errors[0].message").value("비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요."))
         ;
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원을 삭제하면 404를 반환한다.")
+    void delete_fail_member_not_found() throws Exception {
+        // given
+        Long memberId = 1L;
+
+        // memberService.findById()가 null을 반환하도록 설정
+        when(memberService.findById(memberId)).thenReturn(null);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.delete("/api/member/{memberId}", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("존재하는 회원을 삭제하면 200을 반환한다.")
+    void delete_success_member() throws Exception {
+        // given
+        Long memberId = 1L;
+
+        Member member = Member.builder()
+                .email("test@naver.com")
+                .password("password123!")
+                .nickName("testUser")
+                .build();
+
+        when(memberService.findById(memberId)).thenReturn(member);
+        doNothing().when(memberService).delete(memberId);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.delete("/api/member/{memberId}", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk());
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #46, #48, #49

## 📝 작업 내용

> 회원 탈퇴 로직 작성
> 회원 탈퇴 테스트 코드 작성

### 스크린샷 (선택)
![스크린샷 2025-03-18 오전 10 59 52](https://github.com/user-attachments/assets/a5d0bf77-0908-42d9-84d1-a92931122f92)
![스크린샷 2025-03-18 오전 11 00 27](https://github.com/user-attachments/assets/b477cd1f-14fa-4bf5-bd6c-e14dbdc46a1a)
![스크린샷 2025-03-18 오전 11 16 02](https://github.com/user-attachments/assets/2e55a91b-d02e-4203-85b7-55dc9145c724)
![스크린샷 2025-03-18 오전 11 16 25](https://github.com/user-attachments/assets/88125e18-0235-43ad-87f8-27105d55ef68)

## 💬 리뷰 요구사항(선택)
> 회원 탈퇴는 호출 시 바로 탈퇴되도록 하였습니다.
