### PR TITLE
test: 리뷰 삭제 시 피드에도 업데이트 반영하기 테스트

### DIFF
--- a/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeIntegrationTest.java
+++ b/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeIntegrationTest.java
@@ -1,0 +1,55 @@
+package com.flab.readnshare.domain.feed.facade;
+
+import com.flab.readnshare.FeedTestFixture;
+import com.flab.readnshare.ReviewTestFixture;
+import com.flab.readnshare.domain.review.domain.Review;
+import com.flab.readnshare.domain.review.service.ReviewService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class FeedFacadeIntegrationTest {
+
+    @Autowired
+    FeedFacade feedFacade;
+
+    @Autowired
+    ReviewService reviewService;
+
+    @Autowired
+    RedisTemplate<String, Object> feedRedisTemplate;
+
+    @DisplayName("특정 피드를 삭제한다.")
+    @Test
+    void deleteFeed() throws Exception {
+        // Given
+        List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        Long timestamp = System.currentTimeMillis();
+
+        for (Long followerId : followerIds) {
+            String userFeedKey = String.format("user:%d:feed", followerId);
+            feedRedisTemplate.opsForZSet().add(userFeedKey, String.valueOf(reviewId), timestamp);
+        }
+
+        // When
+        feedFacade.deleteToFeed(followerIds, reviewId);
+
+        // Then
+        for (Long followerId : followerIds) {
+            String userFeedKey = String.format("user:%d:feed", followerId);
+            Set<Object> beforeDelete = feedRedisTemplate.opsForZSet().range(userFeedKey, 0, -1);
+            assertThat(beforeDelete).hasSize(0)
+                    .isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeTest.java
+++ b/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -127,6 +128,22 @@ class FeedFacadeTest {
             assertEquals(review.getContent(), dto.getContent());
             assertEquals(review.getBook().getTitle(), dto.getBookTitle());
         }
+    }
+
+    @DisplayName("특정 피드를 삭제한다.")
+    @Test
+    void deleteFeed() throws Exception {
+        // Given
+        List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        when(redisTemplate.executePipelined(any(RedisCallback.class))).thenReturn(null);
+
+        // When
+        feedFacade.deleteToFeed(followerIds, reviewId);
+
+        // Then
+        verify(redisTemplate, times(1)).executePipelined(any(RedisCallback.class));
     }
 
     private Review createMockReview(Long id, String content, String nickName, String bookTitle) {

--- a/src/test/java/com/flab/readnshare/domain/review/controller/ReviewApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/review/controller/ReviewApiControllerTest.java
@@ -3,15 +3,18 @@ package com.flab.readnshare.domain.review.controller;
 import com.flab.readnshare.ReviewTestFixture;
 import com.flab.readnshare.domain.book.dto.BookDto;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.dto.SaveReviewRequestDto;
 import com.flab.readnshare.domain.review.facade.ReviewFacade;
 import com.flab.readnshare.domain.review.service.ReviewService;
 import com.flab.readnshare.global.common.advice.ApiExceptionAdvice;
+import com.flab.readnshare.global.common.exception.ReviewException;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -23,8 +26,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -127,6 +132,59 @@ class ReviewApiControllerTest {
                 .andExpect(jsonPath("$.message").value("입력값을 확인하세요."))
                 .andExpect(jsonPath("$.errors[0].field").value("book.title"))
                 .andExpect(jsonPath("$.errors[0].message").value("책 제목이 없습니다."));
+    }
+
+    @DisplayName("독서 기록 삭제에 성공한다.")
+    @Test
+    void delete_review_success() throws Exception {
+        // Given
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        doNothing().when(reviewFacade).delete(anyLong(), any(Member.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/review/{reviewId}", reviewId)
+        );
+
+        // Then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @DisplayName("존재하지 않는 리뷰를 삭제하면 REVIEW_NOT_FOUND 예외가 발생한다.")
+    @Test
+    void delete_review_fail_not_found() throws Exception {
+        // Given
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        doThrow(new ReviewException.ReviewNotFoundException()).when(reviewFacade).delete(anyLong(), any(Member.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/review/{reviewId}", reviewId)
+        );
+
+        // Then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("존재하지 않는 독서 기록 입니다."));
+    }
+
+    @DisplayName("삭제 권한이 없는 사용자가 리뷰를 삭제할 경우 REVIEW_FORBIDDEN_MEMBER 에러가 발생한다.")
+    @Test
+    void delete_review_fail_no_permission() throws Exception {
+        // Given
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        doThrow(new ReviewException.ForbiddenMemberException()).when(reviewFacade).delete(anyLong(), any(Member.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/review/{reviewId}", reviewId)
+        );
+
+        // Then
+        resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("해당 독서 기록에 대한 수정 및 삭제 권한이 없습니다."));
     }
 
 }

--- a/src/test/java/com/flab/readnshare/domain/review/facade/ReviewFacadeTest.java
+++ b/src/test/java/com/flab/readnshare/domain/review/facade/ReviewFacadeTest.java
@@ -2,12 +2,11 @@ package com.flab.readnshare.domain.review.facade;
 
 import com.flab.readnshare.ReviewTestFixture;
 import com.flab.readnshare.domain.book.service.BookService;
-import com.flab.readnshare.domain.follow.event.FollowEvent;
-import com.flab.readnshare.domain.follow.service.FollowService;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.dto.SaveReviewRequestDto;
-import com.flab.readnshare.domain.review.event.ReviewEvent;
+import com.flab.readnshare.domain.review.event.ReviewCreateEvent;
+import com.flab.readnshare.domain.review.event.ReviewDeleteEvent;
 import com.flab.readnshare.domain.review.service.ReviewService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,23 @@ class ReviewFacadeTest {
         assertNotNull(savedReviewId);
         assertEquals(1L, savedReviewId);
         verify(reviewService, times(1)).save(any(Review.class));
-        verify(eventPublisher).publishEvent(any(ReviewEvent.class));
+        verify(eventPublisher).publishEvent(any(ReviewCreateEvent.class));
+    }
+
+    @DisplayName("독서 기록을 삭제하면 review가 삭제된다.")
+    @Test
+    void delete_review_success() {
+        // Given
+        Member member = ReviewTestFixture.getMemberEntity();
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+
+        // When
+        reviewFacade.delete(reviewId, member);
+
+        // Then
+        verify(reviewService, times(1)).delete(anyLong(), any(Member.class));
+        verify(eventPublisher, times(1)).publishEvent(any(ReviewDeleteEvent.class));
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #40, #58

## 📝 작업 내용

> FeedFacadeIntegrationTest로 Redis와 연결하여 통합 테스트 진행
> 나머지 테스트는 모킹 처리된 단위 테스트

### 스크린샷 (선택)
![스크린샷 2025-03-18 오후 1 05 18](https://github.com/user-attachments/assets/f2169cbf-c2e9-4bfe-9c6a-7c6d12b0ee0c)
![스크린샷 2025-03-18 오후 1 05 29](https://github.com/user-attachments/assets/a478a7e9-4b9b-49a9-914c-f868eab405b4)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
