### PR TITLE
feat: 리뷰가 수정/삭제 되었을 때 피드에도 업데이트 반영하기

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/feed/facade/FeedFacade.java
+++ b/src/main/java/com/flab/readnshare/domain/feed/facade/FeedFacade.java
@@ -77,4 +77,14 @@ public class FeedFacade {
                         .build())
                 .collect(Collectors.toList());
     }
+
+    public void deleteToFeed(List<Long> followerIds, Long reviewId) {
+        feedRedisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            for (Long followerId : followerIds) {
+                String userFeedKey = String.format(KEY, followerId);
+                feedRedisTemplate.opsForZSet().remove(userFeedKey, String.valueOf(reviewId));
+            }
+            return null;
+        });
+    }
 }

--- a/src/main/java/com/flab/readnshare/domain/review/controller/ReviewApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/review/controller/ReviewApiController.java
@@ -37,7 +37,7 @@ public class ReviewApiController {
 
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<Void> delete(@PathVariable Long reviewId, @SignInMember Member signInMember) {
-        reviewService.delete(reviewId, signInMember);
+        reviewFacade.delete(reviewId, signInMember);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/review/event/ReviewCreateEvent.java
+++ b/src/main/java/com/flab/readnshare/domain/review/event/ReviewCreateEvent.java
@@ -5,11 +5,11 @@ import com.flab.readnshare.domain.review.domain.Review;
 import lombok.Getter;
 
 @Getter
-public class ReviewEvent {
+public class ReviewCreateEvent {
     private final Member member;
     private final Review review;
 
-    public ReviewEvent(Member member, Review review) {
+    public ReviewCreateEvent(Member member, Review review) {
         this.member = member;
         this.review = review;
     }

--- a/src/main/java/com/flab/readnshare/domain/review/event/ReviewDeleteEvent.java
+++ b/src/main/java/com/flab/readnshare/domain/review/event/ReviewDeleteEvent.java
@@ -1,0 +1,15 @@
+package com.flab.readnshare.domain.review.event;
+
+import com.flab.readnshare.domain.member.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class ReviewDeleteEvent {
+    private final Member member;
+    private final Long reviewId;
+
+    public ReviewDeleteEvent(Member member, Long reviewId) {
+        this.member = member;
+        this.reviewId = reviewId;
+    }
+}

--- a/src/main/java/com/flab/readnshare/domain/review/event/ReviewEventListener.java
+++ b/src/main/java/com/flab/readnshare/domain/review/event/ReviewEventListener.java
@@ -17,7 +17,7 @@ public class ReviewEventListener {
     private final FeedFacade feedFacade;
 
     @TransactionalEventListener
-    private void updateFollowersFeed(ReviewEvent event) {
+    private void updateFollowersFeed(ReviewCreateEvent event) {
         Member writer = event.getMember();
         Review review = event.getReview();
 
@@ -25,6 +25,17 @@ public class ReviewEventListener {
 
         if (!followerIds.isEmpty()) {
             feedFacade.addToFeed(followerIds, review);
+        }
+    }
+
+    @TransactionalEventListener
+    private void deleteReviewFromFeed(ReviewDeleteEvent event) {
+        Member writer = event.getMember();
+        Long reviewId = event.getReviewId();
+
+        List<Long> followerIds = followService.getFollowerIds(writer);
+        if (!followerIds.isEmpty()) {
+            feedFacade.deleteToFeed(followerIds, reviewId);
         }
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/review/facade/ReviewFacade.java
+++ b/src/main/java/com/flab/readnshare/domain/review/facade/ReviewFacade.java
@@ -6,7 +6,8 @@ import com.flab.readnshare.domain.book.service.BookService;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.dto.SaveReviewRequestDto;
-import com.flab.readnshare.domain.review.event.ReviewEvent;
+import com.flab.readnshare.domain.review.event.ReviewCreateEvent;
+import com.flab.readnshare.domain.review.event.ReviewDeleteEvent;
 import com.flab.readnshare.domain.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -29,8 +30,15 @@ public class ReviewFacade {
         Review review = dto.toEntity(signInMember, book);
         Long reviewId = reviewService.save(review);
 
-        eventPublisher.publishEvent(new ReviewEvent(signInMember, review));
+        eventPublisher.publishEvent(new ReviewCreateEvent(signInMember, review));
 
         return reviewId;
+    }
+
+    @Transactional
+    public void delete(Long reviewId, Member signInMember) {
+        reviewService.delete(reviewId, signInMember);
+
+        eventPublisher.publishEvent(new ReviewDeleteEvent(signInMember, reviewId));
     }
 }

--- a/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeIntegrationTest.java
+++ b/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeIntegrationTest.java
@@ -1,0 +1,55 @@
+package com.flab.readnshare.domain.feed.facade;
+
+import com.flab.readnshare.FeedTestFixture;
+import com.flab.readnshare.ReviewTestFixture;
+import com.flab.readnshare.domain.review.domain.Review;
+import com.flab.readnshare.domain.review.service.ReviewService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class FeedFacadeIntegrationTest {
+
+    @Autowired
+    FeedFacade feedFacade;
+
+    @Autowired
+    ReviewService reviewService;
+
+    @Autowired
+    RedisTemplate<String, Object> feedRedisTemplate;
+
+    @DisplayName("특정 피드를 삭제한다.")
+    @Test
+    void deleteFeed() throws Exception {
+        // Given
+        List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        Long timestamp = System.currentTimeMillis();
+
+        for (Long followerId : followerIds) {
+            String userFeedKey = String.format("user:%d:feed", followerId);
+            feedRedisTemplate.opsForZSet().add(userFeedKey, String.valueOf(reviewId), timestamp);
+        }
+
+        // When
+        feedFacade.deleteToFeed(followerIds, reviewId);
+
+        // Then
+        for (Long followerId : followerIds) {
+            String userFeedKey = String.format("user:%d:feed", followerId);
+            Set<Object> beforeDelete = feedRedisTemplate.opsForZSet().range(userFeedKey, 0, -1);
+            assertThat(beforeDelete).hasSize(0)
+                    .isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeTest.java
+++ b/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.*;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -127,6 +128,22 @@ class FeedFacadeTest {
             assertEquals(review.getContent(), dto.getContent());
             assertEquals(review.getBook().getTitle(), dto.getBookTitle());
         }
+    }
+
+    @DisplayName("특정 피드를 삭제한다.")
+    @Test
+    void deleteFeed() throws Exception {
+        // Given
+        List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        when(redisTemplate.executePipelined(any(RedisCallback.class))).thenReturn(null);
+
+        // When
+        feedFacade.deleteToFeed(followerIds, reviewId);
+
+        // Then
+        verify(redisTemplate, times(1)).executePipelined(any(RedisCallback.class));
     }
 
     private Review createMockReview(Long id, String content, String nickName, String bookTitle) {

--- a/src/test/java/com/flab/readnshare/domain/review/controller/ReviewApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/review/controller/ReviewApiControllerTest.java
@@ -3,15 +3,18 @@ package com.flab.readnshare.domain.review.controller;
 import com.flab.readnshare.ReviewTestFixture;
 import com.flab.readnshare.domain.book.dto.BookDto;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.dto.SaveReviewRequestDto;
 import com.flab.readnshare.domain.review.facade.ReviewFacade;
 import com.flab.readnshare.domain.review.service.ReviewService;
 import com.flab.readnshare.global.common.advice.ApiExceptionAdvice;
+import com.flab.readnshare.global.common.exception.ReviewException;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -23,8 +26,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -127,6 +132,59 @@ class ReviewApiControllerTest {
                 .andExpect(jsonPath("$.message").value("입력값을 확인하세요."))
                 .andExpect(jsonPath("$.errors[0].field").value("book.title"))
                 .andExpect(jsonPath("$.errors[0].message").value("책 제목이 없습니다."));
+    }
+
+    @DisplayName("독서 기록 삭제에 성공한다.")
+    @Test
+    void delete_review_success() throws Exception {
+        // Given
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        doNothing().when(reviewFacade).delete(anyLong(), any(Member.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/review/{reviewId}", reviewId)
+        );
+
+        // Then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @DisplayName("존재하지 않는 리뷰를 삭제하면 REVIEW_NOT_FOUND 예외가 발생한다.")
+    @Test
+    void delete_review_fail_not_found() throws Exception {
+        // Given
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        doThrow(new ReviewException.ReviewNotFoundException()).when(reviewFacade).delete(anyLong(), any(Member.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/review/{reviewId}", reviewId)
+        );
+
+        // Then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("존재하지 않는 독서 기록 입니다."));
+    }
+
+    @DisplayName("삭제 권한이 없는 사용자가 리뷰를 삭제할 경우 REVIEW_FORBIDDEN_MEMBER 에러가 발생한다.")
+    @Test
+    void delete_review_fail_no_permission() throws Exception {
+        // Given
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+        doThrow(new ReviewException.ForbiddenMemberException()).when(reviewFacade).delete(anyLong(), any(Member.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/review/{reviewId}", reviewId)
+        );
+
+        // Then
+        resultActions.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("해당 독서 기록에 대한 수정 및 삭제 권한이 없습니다."));
     }
 
 }

--- a/src/test/java/com/flab/readnshare/domain/review/facade/ReviewFacadeTest.java
+++ b/src/test/java/com/flab/readnshare/domain/review/facade/ReviewFacadeTest.java
@@ -2,12 +2,11 @@ package com.flab.readnshare.domain.review.facade;
 
 import com.flab.readnshare.ReviewTestFixture;
 import com.flab.readnshare.domain.book.service.BookService;
-import com.flab.readnshare.domain.follow.event.FollowEvent;
-import com.flab.readnshare.domain.follow.service.FollowService;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.dto.SaveReviewRequestDto;
-import com.flab.readnshare.domain.review.event.ReviewEvent;
+import com.flab.readnshare.domain.review.event.ReviewCreateEvent;
+import com.flab.readnshare.domain.review.event.ReviewDeleteEvent;
 import com.flab.readnshare.domain.review.service.ReviewService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,23 @@ class ReviewFacadeTest {
         assertNotNull(savedReviewId);
         assertEquals(1L, savedReviewId);
         verify(reviewService, times(1)).save(any(Review.class));
-        verify(eventPublisher).publishEvent(any(ReviewEvent.class));
+        verify(eventPublisher).publishEvent(any(ReviewCreateEvent.class));
+    }
+
+    @DisplayName("독서 기록을 삭제하면 review가 삭제된다.")
+    @Test
+    void delete_review_success() {
+        // Given
+        Member member = ReviewTestFixture.getMemberEntity();
+        Review review = ReviewTestFixture.getReviewEntity();
+        Long reviewId = review.getId();
+
+        // When
+        reviewFacade.delete(reviewId, member);
+
+        // Then
+        verify(reviewService, times(1)).delete(anyLong(), any(Member.class));
+        verify(eventPublisher, times(1)).publishEvent(any(ReviewDeleteEvent.class));
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #50, #58

## 📝 작업 내용

> 리뷰 수정 시 피드에도 업데이트 반영하기
> 리뷰 수정 시 피드에도 업데이트 반영하기 테스트
> 리뷰 삭제 시 피드에도 업데이트 반영하기
> 리뷰 삭제 시 피드에도 업데이트 반영하기 테스트
> 발생하는 버그 및 에러 파악 후 문서화하기

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 1. 수정해도 최초 등록 시점 기준으로 score 처리하기로 결정했기 때문에 수정시 피드에 업데이트 로직이 필요없음
왜냐하면, feed를 저장할 때 reviewId만 저장하기 때문입니다.
> 2. Redis에 직접 데이터가 저장되고 삭제되는 것을 확인하기 위해 FeedFacadeIntegrationTest을 추가했습니다.
> 3. 발생하는 버그 및 에러가 없습니다.
