### PR TITLE
refactor: 로그인 시 평문 비밀번호 대신 암호화된 비밀번호 비교

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+	// spring security crtpto
+	implementation 'org.springframework.security:spring-security-crypto'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/flab/readnshare/domain/auth/service/AuthService.java
+++ b/src/main/java/com/flab/readnshare/domain/auth/service/AuthService.java
@@ -9,27 +9,30 @@ import com.flab.readnshare.global.common.exception.AuthException;
 import com.flab.readnshare.global.common.exception.MemberException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * 로그인
      */
     public Member signIn(SignInRequestDto dto) {
         Member member = memberRepository.findByEmail(dto.getEmail()).orElseThrow(MemberException.MemberNotFoundException::new);
-
-        if (member.getPassword().equals(dto.getPassword())) {
-            return member;
+        if(!passwordEncoder.matches(dto.getPassword(), member.getPassword())){
+            throw new AuthException.InvalidPasswordException();
         }
-        throw new AuthException.InvalidPasswordException();
+        return member;
     }
 
     public void sendAccessToken(HttpServletResponse response, Long memberId) {

--- a/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
@@ -13,13 +13,13 @@ public enum ErrorCode {
 
     // Member
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "이메일 또는 패스워드가 일치하지 않습니다."),
 
     // Auth
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     JWT_DENIED(HttpStatus.UNAUTHORIZED, "조작되거나 지원되지 않는 토큰입니다."),
     JWT_NULL(HttpStatus.UNAUTHORIZED, "토큰이 없습니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "이메일 또는 패스워드가 일치하지 않습니다."),
 
     // Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 독서 기록 입니다."),

--- a/src/main/java/com/flab/readnshare/global/config/WebMvcConfig.java
+++ b/src/main/java/com/flab/readnshare/global/config/WebMvcConfig.java
@@ -5,7 +5,11 @@ import com.flab.readnshare.global.common.auth.jwt.JwtAuthInterceptor;
 import com.flab.readnshare.global.common.auth.jwt.JwtUtil;
 import com.flab.readnshare.global.common.resolver.SignInMemberArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -32,5 +36,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new SignInMemberArgumentResolver(jwtUtil, memberRepository));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/test/java/com/flab/readnshare/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/auth/service/AuthServiceTest.java
@@ -11,7 +11,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
@@ -28,6 +32,9 @@ class AuthServiceTest {
     @InjectMocks
     AuthService authService;
 
+    @Spy
+    private PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
     @Test
     @DisplayName("로그인을 하면 member를 리턴한다")
     void signIn_success_return_member() {
@@ -36,7 +43,7 @@ class AuthServiceTest {
 
         Member expectedMember = Member.builder()
                 .email(request.getEmail())
-                .password(request.getPassword())
+                .password(passwordEncoder.encode(request.getPassword()))
                 .build();
 
         when(memberRepository.findByEmail(any(String.class))).thenReturn(Optional.ofNullable(expectedMember));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #61 

## 📝 작업 내용

> 로그인 로직에서 평문 비밀번호 검증 방식을 암호화 검증으로 변경하였습니다.
