### PR TITLE
test: FCM 토큰 저장 및 조회 테스트

### DIFF
--- a/src/test/java/com/flab/readnshare/domain/notification/repository/FCMTokenRepositoryTest.java
+++ b/src/test/java/com/flab/readnshare/domain/notification/repository/FCMTokenRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.flab.readnshare.domain.notification.repository;
+
+import com.flab.readnshare.domain.notification.domain.FCMToken;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FCMTokenRepositoryTest {
+
+    @Autowired
+    FCMTokenRepository fcmTokenRepository;
+
+    @AfterEach
+    void tearDown() {
+        fcmTokenRepository.deleteAll();
+    }
+
+    @DisplayName("FCM 토큰을 저장한다.")
+    @Test
+    void saveFcmToken() throws Exception {
+        // Given
+        FCMToken fcmToken = FCMToken.builder()
+                .memberId(1L)
+                .fcmTokenValue("test")
+                .build();
+        fcmTokenRepository.save(fcmToken);
+
+        // When
+        Iterable<FCMToken> tokens = fcmTokenRepository.findAll();
+
+        // Then
+        Assertions.assertThat(tokens).hasSize(1)
+                .extracting("memberId", "fcmTokenValue")
+                .containsExactly(
+                        Tuple.tuple(1L, "test")
+                );
+    }
+
+}

--- a/src/test/java/com/flab/readnshare/domain/notification/service/FCMServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/notification/service/FCMServiceTest.java
@@ -1,0 +1,29 @@
+package com.flab.readnshare.domain.notification.service;
+
+import com.flab.readnshare.global.common.exception.MemberException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class FCMServiceTest {
+
+    @Autowired
+    FCMService fcmService;
+
+    @DisplayName("존재하지 않는 유저의 FCM 토큰을 조회할 시 MEMBER_NOT_FOUND 에러가 발생한다.")
+    @Test
+    void getFcmToken_fail_not_found() throws Exception {
+        // Given
+        Long memberId = 9L;
+        // When
+        // Then
+        Assertions.assertThatThrownBy(() -> fcmService.getFCMToken(memberId))
+                .isInstanceOf(MemberException.MemberNotFoundException.class)
+                .hasMessage("존재하지 않는 회원입니다.");
+
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #74

## 📝 작업 내용

> 토큰 저장 및 조회
> 존재하지 않는 유저 FCM 토큰 조회 시 예외 발생

### 스크린샷 (선택)
![스크린샷 2025-03-18 오후 4 50 42](https://github.com/user-attachments/assets/84f09df6-0eba-4f01-bd3f-5e06aafb1843)

## 💬 리뷰 요구사항(선택)

> 더 필요한 테스트가 있을까요?
