### PR TITLE
feat: 이메일로 멤버 검색 기능 추가

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
@@ -34,4 +31,15 @@ public class MemberApiController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<MemberResponseDto> searchMember(@Valid @RequestParam String email){
+        Member member = memberService.findByEmail(email);
+
+        MemberResponseDto responseDto = MemberResponseDto.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickName(member.getNickName())
+                .build();
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #55

## 📝 작업 내용
- 성공 시 id, email, nickName 리턴
- 철자나 대소문자 구분하여 정확하게 입력해야 검색 가능

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d2664636-aee5-43c5-8156-bd5b0ff77429)
![image](https://github.com/user-attachments/assets/85bedab0-b154-4a2a-8f59-ff62ead5e919)

## 💬 리뷰 요구사항(선택)

> @RequestParam 이용해서 구현했습니다.
