### PR TITLE
test: 이메일로 멤버 검색 기능 테스트 코드 추가

### DIFF
--- a/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
@@ -1,5 +1,6 @@
 package com.flab.readnshare.domain.member.controller;
 
+import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.service.MemberService;
@@ -147,4 +148,50 @@ class MemberApiControllerTest {
         ;
     }
 
+    @Test
+    @DisplayName("이메일로 회원 검색 성공")
+    void searchMember_Success() throws Exception {
+        // given
+        String email = "test@naver.com";
+        Member member = Member.builder()
+                .id(1L)
+                .email(email)
+                .nickName("testUser")
+                .build();
+
+        when(memberService.findByEmail(email)).thenReturn(member);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/member/search")
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(member.getId()))
+                .andExpect(jsonPath("$.email").value(member.getEmail()))
+                .andExpect(jsonPath("$.nickName").value(member.getNickName()));
+    }
+
+    @Test
+    @DisplayName("이메일로 회원 검색 실패 - 존재하지 않는 회원")
+    void searchMember_Fail_NotFound() throws Exception {
+        // given
+        String email = "notfound@naver.com";
+
+        when(memberService.findByEmail(email)).thenThrow(new MemberException.MemberNotFoundException());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/member/search")
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #56

## 📝 작업 내용
> 이메일로 검색 성공했을 때
> 존재하지 않은 회원을 검색 했을 때

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e993a501-a593-4ca0-88e8-28f2af17163f)
![image](https://github.com/user-attachments/assets/3b329cd3-481f-4c31-98e4-01188b9c0d41)


## 💬 리뷰 요구사항(선택)
> 2가지 테스트만 진행했습니다.
