### PR TITLE
feat: 이메일로 사용자 검색 기능 추가

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
@@ -34,4 +31,15 @@ public class MemberApiController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    @GetMapping("/search")
+    public ResponseEntity<MemberResponseDto> searchMember(@Valid @RequestParam String email){
+        Member member = memberService.findByEmail(email);
+
+        MemberResponseDto responseDto = MemberResponseDto.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickName(member.getNickName())
+                .build();
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
 }

--- a/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
@@ -1,5 +1,6 @@
 package com.flab.readnshare.domain.member.controller;
 
+import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.service.MemberService;
@@ -147,4 +148,50 @@ class MemberApiControllerTest {
         ;
     }
 
+    @Test
+    @DisplayName("이메일로 회원 검색 성공")
+    void searchMember_Success() throws Exception {
+        // given
+        String email = "test@naver.com";
+        Member member = Member.builder()
+                .id(1L)
+                .email(email)
+                .nickName("testUser")
+                .build();
+
+        when(memberService.findByEmail(email)).thenReturn(member);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/member/search")
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(member.getId()))
+                .andExpect(jsonPath("$.email").value(member.getEmail()))
+                .andExpect(jsonPath("$.nickName").value(member.getNickName()));
+    }
+
+    @Test
+    @DisplayName("이메일로 회원 검색 실패 - 존재하지 않는 회원")
+    void searchMember_Fail_NotFound() throws Exception {
+        // given
+        String email = "notfound@naver.com";
+
+        when(memberService.findByEmail(email)).thenThrow(new MemberException.MemberNotFoundException());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/member/search")
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #54, #55, #56

## 📝 작업 내용
> 사용자 검색 기능 로직 작성
> 사용자 검색 기능 테스트 코드 작성

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/bc639b84-0c63-43a2-b81d-2d481c277631)
![image](https://github.com/user-attachments/assets/b430dee2-c23d-4fbe-8493-89fa0d5852b7)
![image](https://github.com/user-attachments/assets/af318d03-8070-4b9a-bdba-49a0db9f0fe6)


## 💬 리뷰 요구사항(선택)
> 이메일을 정확히 입력했을 때 사용자 id, email, nickName이 리턴되도록 하였습니다.
