### PR TITLE
refactor: FollowApiControllerTest 수정

### DIFF
--- a/src/test/java/com/flab/readnshare/domain/follow/controller/FollowApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/follow/controller/FollowApiControllerTest.java
@@ -1,48 +1,100 @@
 package com.flab.readnshare.domain.follow.controller;
 
+import com.flab.readnshare.FollowTestFixture;
 import com.flab.readnshare.domain.follow.facade.FollowFacade;
+import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
-import com.flab.readnshare.global.config.WebMvcConfig;
+import com.flab.readnshare.global.common.advice.ApiExceptionAdvice;
+import com.flab.readnshare.global.common.exception.FollowException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(
-        controllers = FollowApiController.class,
-        excludeFilters = @ComponentScan.Filter(
-                type = FilterType.ASSIGNABLE_TYPE,
-                classes = WebMvcConfig.class
-        )
-)
-@MockBean(JpaMetamodelMappingContext.class)
+
+@ExtendWith(MockitoExtension.class)
 class FollowApiControllerTest {
 
-    @MockBean
+    @Mock
     FollowFacade followFacade;
 
-    @Autowired
+    @InjectMocks
+    FollowApiController followApiController;
+
+    @InjectMocks
+    ApiExceptionAdvice apiExceptionAdvice;
+
     MockMvc mockMvc;
+
+    @BeforeEach
+    void init() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(followApiController)
+                .setControllerAdvice(apiExceptionAdvice)
+                .build();
+    }
+
+    @DisplayName("자기 자신을 팔로우하면 FollowException.SelfFollowException 예외가 발생한다.")
+    @Test
+    void followFailSelfFollow() throws Exception {
+        // Given
+        Member member = FollowTestFixture.getMemberEntity();
+        String memberEmail = member.getEmail();
+        given(followFacade.follow(anyString(), any(Member.class)))
+                .willThrow(new FollowException.SelfFollowException());
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/follow/{memberEmail}", memberEmail)
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("자기 자신을 팔로우 할 수 없습니다."));
+    }
+
+    @DisplayName("이미 팔로우 한 사용자를 팔로우하면 FollowException.DuplicateFollowException 예외가 발생한다.")
+    @Test
+    void followFailDuplicateFollow() throws Exception {
+        // Given
+        Member member = FollowTestFixture.getMemberEntity();
+        String memberEmail = member.getEmail();
+        given(followFacade.follow(anyString(), any(Member.class)))
+                .willThrow(new FollowException.DuplicateFollowException());
+
+        // When
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/follow/{memberEmail}", memberEmail)
+        );
+
+        // Then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이미 해당 사용자를 팔로우하고 있습니다."));
+    }
 
     @DisplayName("특정 유저의 팔로워 목록을 조회한다.")
     @Test
     void followersOf() throws Exception {
         // Given
         List<MemberResponseDto> result = List.of();
-        BDDMockito.given(followFacade.getFollowersOf(anyString()))
+        given(followFacade.getFollowersOf(anyString()))
                 .willReturn(result);
 
         // When
@@ -60,7 +112,7 @@ class FollowApiControllerTest {
     void followingsOf() throws Exception {
         // Given
         List<MemberResponseDto> result = List.of();
-        BDDMockito.given(followFacade.getFollowingsOf(anyString()))
+        given(followFacade.getFollowingsOf(anyString()))
                 .willReturn(result);
 
         // When


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #89

## 📝 작업 내용

> 기존 테스트 코드와의 통일성을 위해 WebMvcTest를 standaloneSetup으로 변경했습니다.

### 스크린샷 (선택)
![스크린샷 2025-03-19 오전 10 48 54](https://github.com/user-attachments/assets/15a7cddd-4dd7-4aee-ae42-704606bc13d2)

## 💬 리뷰 요구사항(선택)
