### PR TITLE
test: Feed 도메인 테스트 코드 추가 및 리팩토링

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/feed/dto/FeedRequestDto.java
+++ b/src/main/java/com/flab/readnshare/domain/feed/dto/FeedRequestDto.java
@@ -1,8 +1,10 @@
 package com.flab.readnshare.domain.feed.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class FeedRequestDto {
     private Long lastReviewId;
     private Integer limit;

--- a/src/main/java/com/flab/readnshare/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/flab/readnshare/domain/review/repository/ReviewRepository.java
@@ -15,6 +15,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r FROM Review r WHERE r.id = :id")
     Optional<Review> findByIdForUpdate(Long id);
 
+    @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member WHERE r.id IN :reviewIds")
     List<Review> findByIdIn(List<Long> reviewIds);
 
     // 책 제목으로 검색

--- a/src/test/java/com/flab/readnshare/domain/feed/controller/FeedApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/feed/controller/FeedApiControllerTest.java
@@ -1,0 +1,83 @@
+package com.flab.readnshare.domain.feed.controller;
+
+import com.flab.readnshare.domain.feed.dto.FeedRequestDto;
+import com.flab.readnshare.domain.feed.dto.FeedResponseDto;
+import com.flab.readnshare.domain.feed.facade.FeedFacade;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class FeedApiControllerTest {
+
+    @Mock
+    FeedFacade feedFacade;
+
+    @InjectMocks
+    FeedApiController feedApiController;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void init() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(feedApiController)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("getFeed 테스트")
+    class getFeedTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            FeedRequestDto request = FeedRequestDto.builder()
+                    .lastReviewId(1L)
+                    .limit(1)
+                    .build();
+
+            FeedResponseDto response = FeedResponseDto.builder()
+                    .reviewId(1L)
+                    .nickName("test")
+                    .content("test")
+                    .bookTitle("test")
+                    .build();
+
+            BDDMockito.given(feedFacade.getFeed(any(), anyLong(), anyInt()))
+                    .willReturn(List.of(response));
+            // When
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/feeds")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(new Gson().toJson(request))
+            );
+
+            // Then
+            resultActions.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.[0].reviewId").value(1L))
+                    .andExpect(jsonPath("$.[0].nickName").value("test"))
+                    .andExpect(jsonPath("$.[0].content").value("test"))
+                    .andExpect(jsonPath("$.[0].bookTitle").value("test"));
+        }
+    }
+
+}

--- a/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeIntegrationTest.java
+++ b/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeIntegrationTest.java
@@ -2,9 +2,17 @@ package com.flab.readnshare.domain.feed.facade;
 
 import com.flab.readnshare.FeedTestFixture;
 import com.flab.readnshare.ReviewTestFixture;
+import com.flab.readnshare.domain.book.domain.Book;
+import com.flab.readnshare.domain.book.repository.BookRepository;
+import com.flab.readnshare.domain.feed.dto.FeedResponseDto;
+import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.repository.MemberRepository;
 import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.service.ReviewService;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,31 +33,142 @@ public class FeedFacadeIntegrationTest {
     ReviewService reviewService;
 
     @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    BookRepository bookRepository;
+
+    @Autowired
     RedisTemplate<String, Object> feedRedisTemplate;
 
-    @DisplayName("특정 피드를 삭제한다.")
-    @Test
-    void deleteFeed() throws Exception {
-        // Given
-        List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
-        Review review = ReviewTestFixture.getReviewEntity();
-        Long reviewId = review.getId();
-        Long timestamp = System.currentTimeMillis();
+    @AfterEach
+    void tearDown() {
+        feedRedisTemplate.delete(feedRedisTemplate.keys("user:*:feed"));
+    }
 
-        for (Long followerId : followerIds) {
-            String userFeedKey = String.format("user:%d:feed", followerId);
-            feedRedisTemplate.opsForZSet().add(userFeedKey, String.valueOf(reviewId), timestamp);
+    @Nested
+    @DisplayName("addToFeed 테스트")
+    class addToFeedTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+            Review review = ReviewTestFixture.getReviewEntity();
+            Long reviewId = review.getId();
+            Long timestamp = System.currentTimeMillis();
+
+            // When
+            for (Long followerId : followerIds) {
+                String userFeedKey = String.format("user:%d:feed", followerId);
+                feedRedisTemplate.opsForZSet().add(userFeedKey, String.valueOf(reviewId), timestamp);
+            }
+
+            // Then
+            for (Long followerId : followerIds) {
+                String userFeedKey = String.format("user:%d:feed", followerId);
+                Set<Object> result = feedRedisTemplate.opsForZSet().range(userFeedKey, 0, -1);
+                assertThat(result).hasSize(1).contains(String.valueOf(reviewId));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getToFeed 테스트")
+    class getToFeedTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            Book book = createBook();
+            bookRepository.save(book);
+            Member member = createMember();
+            memberRepository.save(member);
+            Review review = createReview(member, book);
+
+
+            List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+            Long reviewId = reviewService.save(review);
+            Long timestamp = System.currentTimeMillis();
+            int limit = 10;
+
+            for (Long followerId : followerIds) {
+                String userFeedKey = String.format("user:%d:feed", followerId);
+                feedRedisTemplate.opsForZSet().add(userFeedKey, String.valueOf(reviewId), timestamp);
+            }
+
+            // When
+            List<FeedResponseDto> result = feedFacade.getFeed(followerIds.get(0), null, limit);
+
+            // Then
+            assertThat(result).hasSize(1)
+                    .extracting("reviewId", "nickName", "content", "bookTitle")
+                    .containsExactly(Tuple.tuple(reviewId, member.getNickName(), review.getContent(), book.getTitle()));
         }
 
-        // When
-        feedFacade.deleteToFeed(followerIds, reviewId);
+        @Test
+        @DisplayName("성공 - 점수없음")
+        void success_no_score() throws Exception {
+            // Given
+            List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
 
-        // Then
-        for (Long followerId : followerIds) {
-            String userFeedKey = String.format("user:%d:feed", followerId);
-            Set<Object> beforeDelete = feedRedisTemplate.opsForZSet().range(userFeedKey, 0, -1);
-            assertThat(beforeDelete).hasSize(0)
-                    .isEmpty();
+            // When
+            List<FeedResponseDto> result = feedFacade.getFeed(followerIds.get(0), 999L, 10);
+
+            // Then
+            assertThat(result).hasSize(0).isEmpty();
         }
+    }
+
+    @Nested
+    @DisplayName("deleteToFeed 테스트")
+    class deleteToFeedTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+            Review review = ReviewTestFixture.getReviewEntity();
+            Long reviewId = review.getId();
+            Long timestamp = System.currentTimeMillis();
+
+            for (Long followerId : followerIds) {
+                String userFeedKey = String.format("user:%d:feed", followerId);
+                feedRedisTemplate.opsForZSet().add(userFeedKey, String.valueOf(reviewId), timestamp);
+            }
+
+            // When
+            feedFacade.deleteToFeed(followerIds, reviewId);
+
+            // Then
+            for (Long followerId : followerIds) {
+                String userFeedKey = String.format("user:%d:feed", followerId);
+                Set<Object> beforeDelete = feedRedisTemplate.opsForZSet().range(userFeedKey, 0, -1);
+                assertThat(beforeDelete).hasSize(0)
+                        .isEmpty();
+            }
+        }
+    }
+
+    private Book createBook() {
+        return Book.builder()
+                .title("test")
+                .isbn("test")
+                .build();
+    }
+
+    private Review createReview(Member member, Book book) {
+        return Review.builder()
+                .member(member)
+                .book(book)
+                .content("test")
+                .build();
+    }
+
+    private Member createMember() {
+        return Member.builder()
+                .email("test")
+                .nickName("test")
+                .build();
     }
 }

--- a/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeTest.java
+++ b/src/test/java/com/flab/readnshare/domain/feed/facade/FeedFacadeTest.java
@@ -8,19 +8,22 @@ import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.service.ReviewService;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.*;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -35,115 +38,127 @@ class FeedFacadeTest {
     @InjectMocks
     private FeedFacade feedFacade;
 
-    @Test
-    @DisplayName("피드 데이터를 생성한다.")
-    void add_to_feed_success() {
-        // given
-        List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
-        Review review = ReviewTestFixture.getReviewEntity();
+    @Nested
+    @DisplayName("addToFeed 테스트")
+    class addToFeedTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+            Review review = ReviewTestFixture.getReviewEntity();
+            when(redisTemplate.executePipelined(any(RedisCallback.class))).thenReturn(null);
 
-        // when
-        when(redisTemplate.executePipelined(any(RedisCallback.class))).thenReturn(null);
+            // when
+            feedFacade.addToFeed(followerIds, review);
 
-        feedFacade.addToFeed(followerIds, review);
-
-        verify(redisTemplate, times(1)).executePipelined(any(RedisCallback.class));
-    }
-
-    @Test
-    @DisplayName("피드를 최신 리뷰부터 조회한다.")
-    void get_feed_latest_review() {
-        // given
-        Long memberId = 1L;
-        int limit = 10;
-        String userFeedKey = String.format("user:%d:feed", memberId);
-        Set<Object> feedSet = FeedTestFixture.getFeedSet();
-
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
-
-        when(zSetOperations.reverseRange(anyString(), anyLong(), anyLong()))
-                .thenReturn(feedSet);
-
-        List<Review> reviews = FeedTestFixture.getReviews(feedSet);
-        List<Long> reviewIds = reviews.stream().map(Review::getId).collect(Collectors.toList());
-
-        when(reviewService.findByIdIn(reviewIds)).thenReturn(reviews);
-
-        // when
-        List<FeedResponseDto> feed = feedFacade.getFeed(memberId, null, limit);
-
-        // then
-        verify(zSetOperations).reverseRange(eq(userFeedKey), eq(0L), eq((long) limit - 1));
-        verify(reviewService, times(1)).findByIdIn(anyList());
-
-        assertEquals(feedSet.size(), feed.size());
-        for (Review review : reviews) {
-            FeedResponseDto dto = feed.stream()
-                    .filter(f -> f.getReviewId().equals(review.getId()))
-                    .findFirst()
-                    .orElseThrow(() -> new AssertionError("Review not found in feed"));
-
-            assertEquals(review.getId(), dto.getReviewId());
-            assertEquals(review.getContent(), dto.getContent());
+            // then
+            verify(redisTemplate, times(1)).executePipelined(any(RedisCallback.class));
         }
     }
 
-    @Test
-    @DisplayName("피드를 마지막 리뷰 다음부터 조회한다.")
-    void get_feed_next_review() {
-        // given
-        Long memberId = 1L;
-        Long lastReviewId = 10L;
-        int limit = 5;
-        String userFeedKey = String.format("user:%d:feed", memberId);
-        Double lastReviewScore = 10.0;
-        Set<Object> feedSet = FeedTestFixture.getFeedSet();
+    @Nested
+    @DisplayName("getToFeed 테스트")
+    class getToFeedTest {
+        @Test
+        @DisplayName("성공 - 최신 리뷰부터 조회")
+        void success_latest() {
+            // given
+            Long memberId = 1L;
+            int limit = 10;
+            String userFeedKey = String.format("user:%d:feed", memberId);
+            Set<Object> feedSet = FeedTestFixture.getFeedSet();
 
-        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
-        when(zSetOperations.score(anyString(), eq(String.valueOf(lastReviewId)))).thenReturn(lastReviewScore);
-        when(zSetOperations.reverseRangeByScore(anyString(), anyDouble(), anyDouble(), anyLong(), anyLong())).thenReturn(feedSet);
+            when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
 
-        Review review1 = createMockReview(1L, "좋은 리뷰입니다!", "이순신", "다른 책 제목");
-        Review review2 = createMockReview(2L, "또 다른 리뷰!", "박지성", "다른 책 제목 2");
+            when(zSetOperations.reverseRange(anyString(), anyLong(), anyLong()))
+                    .thenReturn(feedSet);
 
-        List<Review> reviews = List.of(review1, review2);
-        List<Long> reviewIds = reviews.stream().map(Review::getId).collect(Collectors.toList());
+            List<Review> reviews = FeedTestFixture.getReviews(feedSet);
+            List<Long> reviewIds = reviews.stream().map(Review::getId).collect(Collectors.toList());
 
-        when(reviewService.findByIdIn(reviewIds)).thenReturn(reviews);
+            when(reviewService.findByIdIn(reviewIds)).thenReturn(reviews);
 
-        // when
-        List<FeedResponseDto> feed = feedFacade.getFeed(memberId, lastReviewId, limit);
+            // when
+            List<FeedResponseDto> feed = feedFacade.getFeed(memberId, null, limit);
 
-        // then
-        verify(zSetOperations).reverseRangeByScore(eq(userFeedKey), eq(Double.MIN_VALUE), eq(lastReviewScore - 1), eq(0L), eq((long) limit));
-        verify(reviewService).findByIdIn(eq(reviewIds));
+            // then
+            verify(zSetOperations).reverseRange(eq(userFeedKey), eq(0L), eq((long) limit - 1));
+            verify(reviewService, times(1)).findByIdIn(anyList());
 
-        assertEquals(reviews.size(), feed.size());
+            assertEquals(feedSet.size(), feed.size());
+            for (Review review : reviews) {
+                FeedResponseDto dto = feed.stream()
+                        .filter(f -> f.getReviewId().equals(review.getId()))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("Review not found in feed"));
 
-        for (Review review : reviews) {
-            FeedResponseDto dto = feed.stream().filter(f -> f.getReviewId().equals(review.getId())).findFirst().orElse(null);
-            assertNotNull(dto);
-            assertEquals(review.getId(), dto.getReviewId());
-            assertEquals(review.getMember().getNickName(), dto.getNickName());
-            assertEquals(review.getContent(), dto.getContent());
-            assertEquals(review.getBook().getTitle(), dto.getBookTitle());
+                assertEquals(review.getId(), dto.getReviewId());
+                assertEquals(review.getContent(), dto.getContent());
+            }
+        }
+
+        @Test
+        @DisplayName("성공 - 마지막 다음 리뷰부터 조회")
+        void success_next() {
+            // given
+            Long memberId = 1L;
+            Long lastReviewId = 10L;
+            int limit = 5;
+            String userFeedKey = String.format("user:%d:feed", memberId);
+            Double lastReviewScore = 10.0;
+            Set<Object> feedSet = FeedTestFixture.getFeedSet();
+
+            when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+            when(zSetOperations.score(anyString(), eq(String.valueOf(lastReviewId)))).thenReturn(lastReviewScore);
+            when(zSetOperations.reverseRangeByScore(anyString(), anyDouble(), anyDouble(), anyLong(), anyLong())).thenReturn(feedSet);
+
+            Review review1 = createMockReview(1L, "좋은 리뷰입니다!", "이순신", "다른 책 제목");
+            Review review2 = createMockReview(2L, "또 다른 리뷰!", "박지성", "다른 책 제목 2");
+
+            List<Review> reviews = List.of(review1, review2);
+            List<Long> reviewIds = reviews.stream().map(Review::getId).collect(Collectors.toList());
+
+            when(reviewService.findByIdIn(reviewIds)).thenReturn(reviews);
+
+            // when
+            List<FeedResponseDto> feed = feedFacade.getFeed(memberId, lastReviewId, limit);
+
+            // then
+            verify(zSetOperations).reverseRangeByScore(eq(userFeedKey), eq(Double.MIN_VALUE), eq(lastReviewScore - 1), eq(0L), eq((long) limit));
+            verify(reviewService).findByIdIn(eq(reviewIds));
+
+            assertEquals(reviews.size(), feed.size());
+
+            for (Review review : reviews) {
+                FeedResponseDto dto = feed.stream().filter(f -> f.getReviewId().equals(review.getId())).findFirst().orElse(null);
+                assertNotNull(dto);
+                assertEquals(review.getId(), dto.getReviewId());
+                assertEquals(review.getMember().getNickName(), dto.getNickName());
+                assertEquals(review.getContent(), dto.getContent());
+                assertEquals(review.getBook().getTitle(), dto.getBookTitle());
+            }
         }
     }
 
-    @DisplayName("특정 피드를 삭제한다.")
-    @Test
-    void deleteFeed() throws Exception {
-        // Given
-        List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
-        Review review = ReviewTestFixture.getReviewEntity();
-        Long reviewId = review.getId();
-        when(redisTemplate.executePipelined(any(RedisCallback.class))).thenReturn(null);
+    @Nested
+    @DisplayName("deleteToFeed 테스트")
+    class deleteToFeedTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            List<Long> followerIds = FeedTestFixture.getFollowerTestIds();
+            Review review = ReviewTestFixture.getReviewEntity();
+            Long reviewId = review.getId();
+            when(redisTemplate.executePipelined(any(RedisCallback.class))).thenReturn(null);
 
-        // When
-        feedFacade.deleteToFeed(followerIds, reviewId);
+            // When
+            feedFacade.deleteToFeed(followerIds, reviewId);
 
-        // Then
-        verify(redisTemplate, times(1)).executePipelined(any(RedisCallback.class));
+            // Then
+            verify(redisTemplate, times(1)).executePipelined(any(RedisCallback.class));
+        }
     }
 
     private Review createMockReview(Long id, String content, String nickName, String bookTitle) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #93

## 📝 작업 내용

> 테스트 코드 메서드명 컨벤션을 위해 메서드명 변경
> LazyInitializationException 예외 발생, N + 1 문제를 해결하기 위해 ReviewRepository 페치 조인 적용
> Feed 도메인에 빠진 테스트들 추가

### 스크린샷 (선택)
![스크린샷 2025-03-19 오후 3 17 41](https://github.com/user-attachments/assets/323085d4-fab5-4f03-bdeb-dac495c2cb7f)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>