### PR TITLE
test: Notification 테스트 코드 추가

### DIFF
--- a/src/test/java/com/flab/readnshare/domain/notification/controller/FCMApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/notification/controller/FCMApiControllerTest.java
@@ -1,0 +1,67 @@
+package com.flab.readnshare.domain.notification.controller;
+
+import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.notification.dto.SaveFCMTokenRequestDto;
+import com.flab.readnshare.domain.notification.service.FCMService;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class FCMApiControllerTest {
+
+    @Mock
+    FCMService fcmService;
+
+    @InjectMocks
+    FCMApiController fcmApiController;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(fcmApiController)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("saveFCMToken 테스트")
+    class saveFCMTokenTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            SaveFCMTokenRequestDto request = SaveFCMTokenRequestDto.builder()
+                    .token("test")
+                    .build();
+
+            willDoNothing()
+                    .given(fcmService).saveFCMToken(any(Member.class), anyString());
+
+            // When
+            ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.post("/api/fcm")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(new Gson().toJson(request))
+            );
+
+            // Then
+            resultActions.andExpect(status().isOk());
+        }
+    }
+}

--- a/src/test/java/com/flab/readnshare/domain/notification/event/FollowEventListenerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/notification/event/FollowEventListenerTest.java
@@ -1,0 +1,52 @@
+package com.flab.readnshare.domain.notification.event;
+
+import com.flab.readnshare.ReviewTestFixture;
+import com.flab.readnshare.domain.follow.event.FollowEvent;
+import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.notification.domain.FollowNotificationContent;
+import com.flab.readnshare.domain.notification.service.NotificationSender;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class FollowEventListenerTest {
+
+    @Mock
+    NotificationSender<FollowNotificationContent> notificationSender;
+
+    @InjectMocks
+    FollowEventListener followEventListener;
+
+    @Nested
+    @DisplayName("handle 테스트")
+    class handleTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            Member toMember = ReviewTestFixture.getMemberEntity();
+            Member fromMember = ReviewTestFixture.getMemberEntity();
+            FollowEvent event = new FollowEvent(new Object(), fromMember, toMember);
+
+            willDoNothing()
+                    .given(notificationSender).sendNotification(any(FollowNotificationContent.class));
+
+            // When
+            followEventListener.handle(event);
+
+            // Then
+            verify(notificationSender, times(1)).sendNotification(any(FollowNotificationContent.class));
+        }
+    }
+
+}

--- a/src/test/java/com/flab/readnshare/domain/notification/event/LikeEventListenerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/notification/event/LikeEventListenerTest.java
@@ -1,0 +1,49 @@
+package com.flab.readnshare.domain.notification.event;
+
+import com.flab.readnshare.ReviewTestFixture;
+import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.notification.domain.LikeNotificationContent;
+import com.flab.readnshare.domain.notification.service.NotificationSender;
+import com.flab.readnshare.domain.review.domain.Review;
+import com.flab.readnshare.domain.review.event.LikeEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LikeEventListenerTest {
+
+    @Mock
+    NotificationSender<LikeNotificationContent> notificationSender;
+
+    @InjectMocks
+    LikeEventListener likeEventListener;
+
+    @Nested
+    @DisplayName("handle 테스트")
+    class handleTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            Review review = ReviewTestFixture.getReviewEntity();
+            Member member = ReviewTestFixture.getMemberEntity();
+            LikeEvent event = new LikeEvent(new Object(), member, review);
+
+            willDoNothing()
+                    .given(notificationSender).sendNotification(any(LikeNotificationContent.class));
+
+            // When
+            likeEventListener.handle(event);
+
+            // Then
+            verify(notificationSender, times(1)).sendNotification(any(LikeNotificationContent.class));
+        }
+    }
+}

--- a/src/test/java/com/flab/readnshare/domain/notification/repository/FCMTokenRepositoryTest.java
+++ b/src/test/java/com/flab/readnshare/domain/notification/repository/FCMTokenRepositoryTest.java
@@ -5,6 +5,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,25 +21,28 @@ class FCMTokenRepositoryTest {
         fcmTokenRepository.deleteAll();
     }
 
-    @DisplayName("FCM 토큰을 저장한다.")
-    @Test
-    void saveFcmToken() throws Exception {
-        // Given
-        FCMToken fcmToken = FCMToken.builder()
-                .memberId(1L)
-                .fcmTokenValue("test")
-                .build();
-        fcmTokenRepository.save(fcmToken);
+    @Nested
+    @DisplayName("saveFCMToken 테스트")
+    class saveFCMToken {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            FCMToken fcmToken = FCMToken.builder()
+                    .memberId(1L)
+                    .fcmTokenValue("test")
+                    .build();
+            fcmTokenRepository.save(fcmToken);
 
-        // When
-        Iterable<FCMToken> tokens = fcmTokenRepository.findAll();
+            // When
+            Iterable<FCMToken> tokens = fcmTokenRepository.findAll();
 
-        // Then
-        Assertions.assertThat(tokens).hasSize(1)
-                .extracting("memberId", "fcmTokenValue")
-                .containsExactly(
-                        Tuple.tuple(1L, "test")
-                );
+            // Then
+            Assertions.assertThat(tokens).hasSize(1)
+                    .extracting("memberId", "fcmTokenValue")
+                    .containsExactly(
+                            Tuple.tuple(1L, "test")
+                    );
+        }
     }
-
 }

--- a/src/test/java/com/flab/readnshare/domain/notification/service/FCMNotificationSenderTest.java
+++ b/src/test/java/com/flab/readnshare/domain/notification/service/FCMNotificationSenderTest.java
@@ -2,6 +2,7 @@ package com.flab.readnshare.domain.notification.service;
 
 import com.flab.readnshare.ReviewTestFixture;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.notification.domain.FollowNotificationContent;
 import com.flab.readnshare.domain.notification.domain.LikeNotificationContent;
 import com.flab.readnshare.domain.review.domain.Review;
 import com.google.api.core.ApiFuture;
@@ -9,6 +10,7 @@ import com.google.api.core.ApiFutures;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,32 +31,63 @@ public class FCMNotificationSenderTest {
     FirebaseMessaging firebaseMessaging;
 
     @InjectMocks
-    FCMNotificationSender<LikeNotificationContent> notificationSender;
+    FCMNotificationSender<LikeNotificationContent> likeNotificationSender;
 
-    @DisplayName("좋아요 이벤트 발행 시 알림이 전송된다.")
-    @Test
-    void sendLikeNotification() throws Exception {
-        // Given
-        Member fromMember = ReviewTestFixture.getMemberEntity();
-        Review toReview = ReviewTestFixture.getReviewEntity();
-        LikeNotificationContent content = LikeNotificationContent.builder()
-                .fromMember(fromMember)
-                .toReview(toReview)
-                .build();
+    @InjectMocks
+    FCMNotificationSender<FollowNotificationContent> followNotificationSender;
 
-        String fcmToken = "token";
-        when(fcmService.getFCMToken(anyLong())).thenReturn(fcmToken);
+    @Nested
+    @DisplayName("sendNotification 테스트")
+    class sendNotificationTest {
+        @Test
+        @DisplayName("성공 - 좋아요 이벤트 발행 시")
+        void success_like() throws Exception {
+            // Given
+            Member fromMember = ReviewTestFixture.getMemberEntity();
+            Review toReview = ReviewTestFixture.getReviewEntity();
+            LikeNotificationContent content = LikeNotificationContent.builder()
+                    .fromMember(fromMember)
+                    .toReview(toReview)
+                    .build();
 
-        ApiFuture<String> futureResponse = ApiFutures.immediateFuture("future");
-        when(firebaseMessaging.sendAsync(any(Message.class))).thenReturn(futureResponse);
+            String fcmToken = "token";
+            when(fcmService.getFCMToken(anyLong())).thenReturn(fcmToken);
 
-        // When
-        try (MockedStatic<FirebaseMessaging> mockStatic = mockStatic(FirebaseMessaging.class)) {
-            mockStatic.when(() -> FirebaseMessaging.getInstance()).thenReturn(firebaseMessaging);
-            notificationSender.sendNotification(content);
+            ApiFuture<String> futureResponse = ApiFutures.immediateFuture("future");
+            when(firebaseMessaging.sendAsync(any(Message.class))).thenReturn(futureResponse);
+
+            // When
+            try (MockedStatic<FirebaseMessaging> mockStatic = mockStatic(FirebaseMessaging.class)) {
+                mockStatic.when(() -> FirebaseMessaging.getInstance()).thenReturn(firebaseMessaging);
+                likeNotificationSender.sendNotification(content);
+            }
+
+            // Then
+            verify(firebaseMessaging, times(1)).sendAsync(any(Message.class));
         }
 
-        // Then
-        verify(firebaseMessaging, times(1)).sendAsync(any(Message.class));
+        @Test
+        @DisplayName("성공 - 팔로우 이벤트 발행 시")
+        void success_follow() throws Exception {
+            // Given
+            Member toMember = ReviewTestFixture.getMemberEntity();
+            Member fromMember = ReviewTestFixture.getMemberEntity();
+            FollowNotificationContent content = FollowNotificationContent.builder()
+                    .fromMember(fromMember)
+                    .toMember(toMember)
+                    .build();
+
+            String fcmToken = "token";
+            when(fcmService.getFCMToken(anyLong())).thenReturn(fcmToken);
+
+            // When
+            try (MockedStatic<FirebaseMessaging> mockStatic = mockStatic(FirebaseMessaging.class)) {
+                mockStatic.when(() -> FirebaseMessaging.getInstance()).thenReturn(firebaseMessaging);
+                followNotificationSender.sendNotification(content);
+            }
+
+            // Then
+            verify(firebaseMessaging, times(1)).sendAsync(any(Message.class));
+        }
     }
 }

--- a/src/test/java/com/flab/readnshare/domain/notification/service/FCMServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/notification/service/FCMServiceTest.java
@@ -1,11 +1,18 @@
 package com.flab.readnshare.domain.notification.service;
 
+import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.repository.MemberRepository;
+import com.flab.readnshare.domain.notification.repository.FCMTokenRepository;
 import com.flab.readnshare.global.common.exception.MemberException;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 class FCMServiceTest {
@@ -13,17 +20,55 @@ class FCMServiceTest {
     @Autowired
     FCMService fcmService;
 
-    @DisplayName("존재하지 않는 유저의 FCM 토큰을 조회할 시 MEMBER_NOT_FOUND 에러가 발생한다.")
-    @Test
-    void getFcmToken_fail_not_found() throws Exception {
-        // Given
-        Long memberId = 9L;
-        // When
-        // Then
-        Assertions.assertThatThrownBy(() -> fcmService.getFCMToken(memberId))
-                .isInstanceOf(MemberException.MemberNotFoundException.class)
-                .hasMessage("존재하지 않는 회원입니다.");
+    @Autowired
+    MemberRepository memberRepository;
 
+    @Autowired
+    FCMTokenRepository fcmTokenRepository;
+
+    @AfterEach
+    void tearDown() {
+        fcmTokenRepository.deleteAll();
     }
 
+    @Nested
+    @DisplayName("getFCMToken 테스트")
+    class getFCMTokenTest {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // Given
+            Member member = createMember("testNick");
+            memberRepository.save(member);
+            String token = "token";
+            fcmService.saveFCMToken(member, token);
+
+            // When
+            String fcmToken = fcmService.getFCMToken(member.getId());
+
+            // Then
+            assertThat(fcmToken).isEqualTo("token");
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 유저의 FCM 토큰 조회")
+        void fail_not_found_user() throws Exception {
+            // Given
+            Long memberId = 9L;
+            // When
+            // Then
+            assertThatThrownBy(() -> fcmService.getFCMToken(memberId))
+                    .isInstanceOf(MemberException.MemberNotFoundException.class)
+                    .hasMessage("존재하지 않는 회원입니다.");
+
+        }
+    }
+
+    private Member createMember(String nickName) {
+        return Member.builder()
+                .email("test")
+                .password(null)
+                .nickName(nickName)
+                .build();
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #104

## 📝 작업 내용

> 테스트 코드 메서드명 컨벤션을 위해 메서드명 변경
> Notification 도메인에 빠진 테스트들 추가

### 스크린샷 (선택)
![스크린샷 2025-03-19 오후 9 45 25](https://github.com/user-attachments/assets/0244a652-0413-4337-8b02-340854a5589a)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
