### PR TITLE
feat: 프로필 이미지 및 소개글 추가 및 기능 개선

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
@@ -1,6 +1,7 @@
 package com.flab.readnshare.domain.member.controller;
 
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.dto.MemberInfoResponseDto;
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
@@ -64,16 +65,17 @@ public class MemberApiController {
 
     // 회원조회
     @GetMapping("/{memberId}")
-    public ResponseEntity<MemberResponseDto> findById(@PathVariable Long memberId) {
+    public ResponseEntity<MemberInfoResponseDto> findById(@PathVariable Long memberId) {
         Member member = memberService.findById(memberId);
 
-        MemberResponseDto responseDto = MemberResponseDto.builder()
+        MemberInfoResponseDto responseInfoDto = MemberInfoResponseDto.builder()
                 .id(member.getId())
                 .email(member.getEmail())
                 .nickName(member.getNickName())
+                .profileContent(member.getProfileContent())
                 .build();
 
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+        return new ResponseEntity<>(responseInfoDto, HttpStatus.OK);
     }
 
     // 회원삭제

--- a/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
@@ -1,5 +1,6 @@
 package com.flab.readnshare.domain.member.controller;
 
+import com.flab.readnshare.domain.member.domain.Image;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.MemberInfoResponseDto;
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
@@ -67,12 +68,14 @@ public class MemberApiController {
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberInfoResponseDto> findById(@PathVariable Long memberId) {
         Member member = memberService.findById(memberId);
+        Image image = memberService.findByImageId(member.getProfileImage());
 
         MemberInfoResponseDto responseInfoDto = MemberInfoResponseDto.builder()
                 .id(member.getId())
                 .email(member.getEmail())
                 .nickName(member.getNickName())
                 .profileContent(member.getProfileContent())
+                .profileImagePath(image.getProfileImagePath())
                 .build();
 
         return new ResponseEntity<>(responseInfoDto, HttpStatus.OK);

--- a/src/main/java/com/flab/readnshare/domain/member/domain/Image.java
+++ b/src/main/java/com/flab/readnshare/domain/member/domain/Image.java
@@ -1,0 +1,26 @@
+package com.flab.readnshare.domain.member.domain;
+
+import com.flab.readnshare.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+    private String profileImagePath;
+
+    @Builder
+    public Image(Long id, String profileImagePath) {
+        this.id = id;
+        this.profileImagePath = profileImagePath;
+    }
+}

--- a/src/main/java/com/flab/readnshare/domain/member/domain/Member.java
+++ b/src/main/java/com/flab/readnshare/domain/member/domain/Member.java
@@ -21,20 +21,30 @@ public class Member extends BaseTimeEntity {
     private String password;
     private String nickName;
     private String profileContent;
+    private Long profileImage;
+
+    @PrePersist
+    public void setDefaultValues() {
+        if (this.profileImage == null) {
+            this.profileImage = 1L; // 기본값 설정
+        }
+    }
 
     @Builder
-    public Member(Long id, String email, String password, String nickName, String profileContent) {
+    public Member(Long id, String email, String password, String nickName, String profileContent, Long profileImage) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.nickName = nickName;
         this.profileContent = profileContent;
+        this.profileImage = profileImage;
     }
 
     // 닉네임, 비밀번호 변경용 updateInfo 추가
-    public void updateInfo(String nickName, String password, String profileContent) {
+    public void updateInfo(String nickName, String password, String profileContent, Long profileImage) {
         this.nickName = nickName;
         this.password = password;
         this.profileContent = profileContent;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/member/domain/Member.java
+++ b/src/main/java/com/flab/readnshare/domain/member/domain/Member.java
@@ -20,18 +20,21 @@ public class Member extends BaseTimeEntity {
     private String email;
     private String password;
     private String nickName;
+    private String profileContent;
 
     @Builder
-    public Member(Long id, String email, String password, String nickName) {
+    public Member(Long id, String email, String password, String nickName, String profileContent) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.nickName = nickName;
+        this.profileContent = profileContent;
     }
 
     // 닉네임, 비밀번호 변경용 updateInfo 추가
-    public void updateInfo(String nickName, String password) {
+    public void updateInfo(String nickName, String password, String profileContent) {
         this.nickName = nickName;
         this.password = password;
+        this.profileContent = profileContent;
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/member/dto/MemberInfoResponseDto.java
+++ b/src/main/java/com/flab/readnshare/domain/member/dto/MemberInfoResponseDto.java
@@ -10,22 +10,14 @@ public class MemberInfoResponseDto {
     private String email;
     private String nickName;
     private String profileContent;
+    private String profileImagePath;
 
     @Builder
-    public MemberInfoResponseDto(Long id, String email, String nickName, String profileContent) {
+    public MemberInfoResponseDto(Long id, String email, String nickName, String profileContent, String profileImagePath) {
         this.id = id;
         this.email = email;
         this.nickName = nickName;
         this.profileContent = profileContent;
+        this.profileImagePath = profileImagePath;
     }
-
-    public Member toEntity(){
-        return Member.builder()
-                .id(id)
-                .email(email)
-                .nickName(nickName)
-                .profileContent(profileContent)
-                .build();
-    }
-
 }

--- a/src/main/java/com/flab/readnshare/domain/member/dto/MemberInfoResponseDto.java
+++ b/src/main/java/com/flab/readnshare/domain/member/dto/MemberInfoResponseDto.java
@@ -1,0 +1,31 @@
+package com.flab.readnshare.domain.member.dto;
+
+import com.flab.readnshare.domain.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberInfoResponseDto {
+    private Long id;
+    private String email;
+    private String nickName;
+    private String profileContent;
+
+    @Builder
+    public MemberInfoResponseDto(Long id, String email, String nickName, String profileContent) {
+        this.id = id;
+        this.email = email;
+        this.nickName = nickName;
+        this.profileContent = profileContent;
+    }
+
+    public Member toEntity(){
+        return Member.builder()
+                .id(id)
+                .email(email)
+                .nickName(nickName)
+                .profileContent(profileContent)
+                .build();
+    }
+
+}

--- a/src/main/java/com/flab/readnshare/domain/member/dto/UpdateRequestDto.java
+++ b/src/main/java/com/flab/readnshare/domain/member/dto/UpdateRequestDto.java
@@ -1,6 +1,8 @@
 package com.flab.readnshare.domain.member.dto;
 
 import com.flab.readnshare.domain.member.domain.Member;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -18,11 +20,16 @@ public class UpdateRequestDto {
 
     private String profileContent;
 
+    @Min(value = 1, message = "프로필 이미지는 최소 1이어야 합니다.")
+    @Max(value = 4, message = "프로필 이미지는 최대 4까지만 허용됩니다.")
+    private Long profileImage;
+
     @Builder
-    public UpdateRequestDto(String password, String nickName, String profileContent) {
+    public UpdateRequestDto(String password, String nickName, String profileContent, Long profileImage) {
         this.password = password;
         this.nickName = nickName;
         this.profileContent = profileContent;
+        this.profileImage = profileImage;
     }
 
     // Member 엔티티로 변환하는 메서드 추가
@@ -31,6 +38,7 @@ public class UpdateRequestDto {
                 .nickName(nickName)
                 .password(passwordEncoder.encode(password)) // 비밀번호 암호화
                 .profileContent(profileContent)
+                .profileImage(profileImage)
                 .build();
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/member/dto/UpdateRequestDto.java
+++ b/src/main/java/com/flab/readnshare/domain/member/dto/UpdateRequestDto.java
@@ -16,17 +16,21 @@ public class UpdateRequestDto {
     @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickName;
 
+    private String profileContent;
+
     @Builder
-    public UpdateRequestDto(String password, String nickName) {
+    public UpdateRequestDto(String password, String nickName, String profileContent) {
         this.password = password;
         this.nickName = nickName;
+        this.profileContent = profileContent;
     }
 
     // Member 엔티티로 변환하는 메서드 추가
     public Member toEntity(PasswordEncoder passwordEncoder) {
         return Member.builder()
-                .password(passwordEncoder.encode(password)) // 비밀번호 암호화
                 .nickName(nickName)
+                .password(passwordEncoder.encode(password)) // 비밀번호 암호화
+                .profileContent(profileContent)
                 .build();
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/member/repository/ImageRepository.java
+++ b/src/main/java/com/flab/readnshare/domain/member/repository/ImageRepository.java
@@ -1,0 +1,12 @@
+package com.flab.readnshare.domain.member.repository;
+
+import com.flab.readnshare.domain.member.domain.Image;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findById(Long id);
+}

--- a/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
@@ -1,9 +1,12 @@
 package com.flab.readnshare.domain.member.service;
 
+import com.flab.readnshare.domain.member.domain.Image;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
+import com.flab.readnshare.domain.member.repository.ImageRepository;
 import com.flab.readnshare.domain.member.repository.MemberRepository;
+import com.flab.readnshare.global.common.exception.ImageException;
 import com.flab.readnshare.global.common.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +24,8 @@ public class MemberService {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+    @Autowired
+    private ImageRepository imageRepository;
 
     /**
      * 회원가입
@@ -48,6 +53,16 @@ public class MemberService {
                 .orElseThrow(MemberException.MemberNotFoundException::new);
     }
 
+    public Image findByImageId(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("이미지 ID는 null이 될 수 없습니다.");
+        }
+
+        return imageRepository.findById(id)
+                .orElseThrow(ImageException.NotFoundImageException::new);
+    }
+
+
     // 멤버 수정
     @Transactional
     public Member update(Long memberId, UpdateRequestDto requestDto, PasswordEncoder passwordEncoder) {
@@ -58,7 +73,10 @@ public class MemberService {
         Member updatedMember = requestDto.toEntity(passwordEncoder);
 
         // 기존 member의 ID와 Email은 유지한 채 업데이트
-        member.updateInfo(updatedMember.getNickName(), updatedMember.getPassword(), updatedMember.getProfileContent());
+        member.updateInfo(updatedMember.getNickName(),
+                          updatedMember.getPassword(),
+                          updatedMember.getProfileContent(),
+                          updatedMember.getProfileImage());
 
         memberRepository.save(member); // 변경 감지로 자동 업데이트
 

--- a/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
@@ -58,7 +58,7 @@ public class MemberService {
         Member updatedMember = requestDto.toEntity(passwordEncoder);
 
         // 기존 member의 ID와 Email은 유지한 채 업데이트
-        member.updateInfo(updatedMember.getNickName(), updatedMember.getPassword());
+        member.updateInfo(updatedMember.getNickName(), updatedMember.getPassword(), updatedMember.getProfileContent());
 
         memberRepository.save(member); // 변경 감지로 자동 업데이트
 

--- a/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
+    // Image
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지가 없습니다."),
+
     // Auth
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     JWT_DENIED(HttpStatus.UNAUTHORIZED, "조작되거나 지원되지 않는 토큰입니다."),

--- a/src/main/java/com/flab/readnshare/global/common/exception/ImageException.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/ImageException.java
@@ -1,0 +1,21 @@
+package com.flab.readnshare.global.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ImageException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ImageException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public static class NotFoundImageException extends ImageException {
+        public NotFoundImageException() {
+            super(ErrorCode.IMAGE_NOT_FOUND);
+        }
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,11 +10,11 @@ spring:
 
   sql:
     init:
-      mode: ${SQL_INIT_MODE:never}
+      mode: ${SQL_INIT_MODE:always}
 
   jpa:
     hibernate:
-      ddl-auto: ${JPA_DDL_AUTO:create}
+      ddl-auto: ${JPA_DDL_AUTO:update}
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #109

## 📝 작업 내용
> 소개글(profileContent) 추가
> 회원 id 조회 시 소개글 확인 가능
> 회원 수정 시 소개글 변경 가능
> Image 테이블 추가 (image_id, profile_image_path)
> NotFoundImage 에러코드 추가
> 기존 Member 테이블에 profileImage 추가 (1~4 중에 선택하도록, 기본값 1)
> memberId 조회 시 profileImagePath가 리턴되도록 수정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/30345bfc-d551-4c55-b381-1a9191388bbd)
![image](https://github.com/user-attachments/assets/7bfa2844-75cc-468a-b5a0-c1b4bd93660c)

## 💬 리뷰 요구사항(선택)

