### PR TITLE
feat: 프로필 이미지 및 소개글 추가에 따른 기능개선 및 테스트코드 수정

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
@@ -1,6 +1,8 @@
 package com.flab.readnshare.domain.member.controller;
 
+import com.flab.readnshare.domain.member.domain.Image;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.dto.MemberInfoResponseDto;
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
@@ -64,16 +66,19 @@ public class MemberApiController {
 
     // 회원조회
     @GetMapping("/{memberId}")
-    public ResponseEntity<MemberResponseDto> findById(@PathVariable Long memberId) {
+    public ResponseEntity<MemberInfoResponseDto> findById(@PathVariable Long memberId) {
         Member member = memberService.findById(memberId);
+        Image image = memberService.findByImageId(member.getProfileImage());
 
-        MemberResponseDto responseDto = MemberResponseDto.builder()
+        MemberInfoResponseDto responseInfoDto = MemberInfoResponseDto.builder()
                 .id(member.getId())
                 .email(member.getEmail())
                 .nickName(member.getNickName())
+                .profileContent(member.getProfileContent())
+                .profileImagePath(image.getProfileImagePath())
                 .build();
 
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+        return new ResponseEntity<>(responseInfoDto, HttpStatus.OK);
     }
 
     // 회원삭제

--- a/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
@@ -37,19 +37,6 @@ public class MemberApiController {
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
-    // 이메일 기반 회원 검색
-    @GetMapping("/search")
-    public ResponseEntity<MemberResponseDto> searchMember(@Valid @RequestParam String email){
-        Member member = memberService.findByEmail(email);
-
-        MemberResponseDto responseDto = MemberResponseDto.builder()
-                .id(member.getId())
-                .email(member.getEmail())
-                .nickName(member.getNickName())
-                .build();
-
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
-    }
     // 회원수정
     @PutMapping("/{memberId}")
     public ResponseEntity<MemberResponseDto> update(@PathVariable Long memberId, @Valid @RequestBody UpdateRequestDto dto){
@@ -64,11 +51,29 @@ public class MemberApiController {
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
+    // 이메일 기반 회원 검색
+    @GetMapping("/search")
+    public ResponseEntity<MemberResponseDto> searchMember(@Valid @RequestParam String email){
+        Member member = memberService.findByEmail(email);
+
+        MemberResponseDto responseDto = MemberResponseDto.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickName(member.getNickName())
+                .build();
+
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
     // 회원조회
     @GetMapping("/{memberId}")
-    public ResponseEntity<MemberInfoResponseDto> findById(@PathVariable Long memberId) {
+    public ResponseEntity<?> findById(@PathVariable Long memberId) {
         Member member = memberService.findById(memberId);
         Image image = memberService.findByImageId(member.getProfileImage());
+
+        if (image == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
 
         MemberInfoResponseDto responseInfoDto = MemberInfoResponseDto.builder()
                 .id(member.getId())
@@ -78,7 +83,7 @@ public class MemberApiController {
                 .profileImagePath(image.getProfileImagePath())
                 .build();
 
-        return new ResponseEntity<>(responseInfoDto, HttpStatus.OK);
+        return ResponseEntity.ok(responseInfoDto);
     }
 
     // 회원삭제

--- a/src/main/java/com/flab/readnshare/domain/member/domain/Image.java
+++ b/src/main/java/com/flab/readnshare/domain/member/domain/Image.java
@@ -1,0 +1,26 @@
+package com.flab.readnshare.domain.member.domain;
+
+import com.flab.readnshare.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long id;
+    private String profileImagePath;
+
+    @Builder
+    public Image(Long id, String profileImagePath) {
+        this.id = id;
+        this.profileImagePath = profileImagePath;
+    }
+}

--- a/src/main/java/com/flab/readnshare/domain/member/domain/Member.java
+++ b/src/main/java/com/flab/readnshare/domain/member/domain/Member.java
@@ -20,18 +20,31 @@ public class Member extends BaseTimeEntity {
     private String email;
     private String password;
     private String nickName;
+    private String profileContent;
+    private Long profileImage;
+
+    @PrePersist
+    public void setDefaultValues() {
+        if (this.profileImage == null) {
+            this.profileImage = 1L; // 기본값 설정
+        }
+    }
 
     @Builder
-    public Member(Long id, String email, String password, String nickName) {
+    public Member(Long id, String email, String password, String nickName, String profileContent, Long profileImage) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.nickName = nickName;
+        this.profileContent = profileContent;
+        this.profileImage = profileImage;
     }
 
     // 닉네임, 비밀번호 변경용 updateInfo 추가
-    public void updateInfo(String nickName, String password) {
+    public void updateInfo(String nickName, String password, String profileContent, Long profileImage) {
         this.nickName = nickName;
         this.password = password;
+        this.profileContent = profileContent;
+        this.profileImage = profileImage;
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/member/dto/MemberInfoResponseDto.java
+++ b/src/main/java/com/flab/readnshare/domain/member/dto/MemberInfoResponseDto.java
@@ -1,0 +1,23 @@
+package com.flab.readnshare.domain.member.dto;
+
+import com.flab.readnshare.domain.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberInfoResponseDto {
+    private Long id;
+    private String email;
+    private String nickName;
+    private String profileContent;
+    private String profileImagePath;
+
+    @Builder
+    public MemberInfoResponseDto(Long id, String email, String nickName, String profileContent, String profileImagePath) {
+        this.id = id;
+        this.email = email;
+        this.nickName = nickName;
+        this.profileContent = profileContent;
+        this.profileImagePath = profileImagePath;
+    }
+}

--- a/src/main/java/com/flab/readnshare/domain/member/dto/UpdateRequestDto.java
+++ b/src/main/java/com/flab/readnshare/domain/member/dto/UpdateRequestDto.java
@@ -1,6 +1,8 @@
 package com.flab.readnshare.domain.member.dto;
 
 import com.flab.readnshare.domain.member.domain.Member;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -16,17 +18,27 @@ public class UpdateRequestDto {
     @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickName;
 
+    private String profileContent;
+
+    @Min(value = 1, message = "프로필 이미지는 최소 1이어야 합니다.")
+    @Max(value = 4, message = "프로필 이미지는 최대 4까지만 허용됩니다.")
+    private Long profileImage;
+
     @Builder
-    public UpdateRequestDto(String password, String nickName) {
+    public UpdateRequestDto(String password, String nickName, String profileContent, Long profileImage) {
         this.password = password;
         this.nickName = nickName;
+        this.profileContent = profileContent;
+        this.profileImage = profileImage;
     }
 
     // Member 엔티티로 변환하는 메서드 추가
     public Member toEntity(PasswordEncoder passwordEncoder) {
         return Member.builder()
-                .password(passwordEncoder.encode(password)) // 비밀번호 암호화
                 .nickName(nickName)
+                .password(passwordEncoder.encode(password)) // 비밀번호 암호화
+                .profileContent(profileContent)
+                .profileImage(profileImage)
                 .build();
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/member/repository/ImageRepository.java
+++ b/src/main/java/com/flab/readnshare/domain/member/repository/ImageRepository.java
@@ -1,0 +1,12 @@
+package com.flab.readnshare.domain.member.repository;
+
+import com.flab.readnshare.domain.member.domain.Image;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findById(Long id);
+}

--- a/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
@@ -21,11 +21,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-    @Autowired
-    private ImageRepository imageRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final ImageRepository imageRepository;
 
     /**
      * 회원가입

--- a/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
@@ -1,9 +1,12 @@
 package com.flab.readnshare.domain.member.service;
 
+import com.flab.readnshare.domain.member.domain.Image;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
+import com.flab.readnshare.domain.member.repository.ImageRepository;
 import com.flab.readnshare.domain.member.repository.MemberRepository;
+import com.flab.readnshare.global.common.exception.ImageException;
 import com.flab.readnshare.global.common.exception.MemberException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +24,8 @@ public class MemberService {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+    @Autowired
+    private ImageRepository imageRepository;
 
     /**
      * 회원가입
@@ -48,6 +53,16 @@ public class MemberService {
                 .orElseThrow(MemberException.MemberNotFoundException::new);
     }
 
+    public Image findByImageId(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("이미지 ID는 null이 될 수 없습니다.");
+        }
+
+        return imageRepository.findById(id)
+                .orElseThrow(ImageException.NotFoundImageException::new);
+    }
+
+
     // 멤버 수정
     @Transactional
     public Member update(Long memberId, UpdateRequestDto requestDto, PasswordEncoder passwordEncoder) {
@@ -58,7 +73,10 @@ public class MemberService {
         Member updatedMember = requestDto.toEntity(passwordEncoder);
 
         // 기존 member의 ID와 Email은 유지한 채 업데이트
-        member.updateInfo(updatedMember.getNickName(), updatedMember.getPassword());
+        member.updateInfo(updatedMember.getNickName(),
+                          updatedMember.getPassword(),
+                          updatedMember.getProfileContent(),
+                          updatedMember.getProfileImage());
 
         memberRepository.save(member); // 변경 감지로 자동 업데이트
 

--- a/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
+    // Image
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지가 없습니다."),
+
     // Auth
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     JWT_DENIED(HttpStatus.UNAUTHORIZED, "조작되거나 지원되지 않는 토큰입니다."),

--- a/src/main/java/com/flab/readnshare/global/common/exception/ImageException.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/ImageException.java
@@ -1,0 +1,21 @@
+package com.flab.readnshare.global.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ImageException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ImageException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public static class NotFoundImageException extends ImageException {
+        public NotFoundImageException() {
+            super(ErrorCode.IMAGE_NOT_FOUND);
+        }
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,11 +10,11 @@ spring:
 
   sql:
     init:
-      mode: ${SQL_INIT_MODE:never}
+      mode: ${SQL_INIT_MODE:always}
 
   jpa:
     hibernate:
-      ddl-auto: ${JPA_DDL_AUTO:create}
+      ddl-auto: ${JPA_DDL_AUTO:update}
     properties:
       hibernate:
         show_sql: true

--- a/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/member/controller/MemberApiControllerTest.java
@@ -1,6 +1,8 @@
 package com.flab.readnshare.domain.member.controller;
 
+import com.flab.readnshare.domain.member.domain.Image;
 import com.flab.readnshare.domain.member.domain.Member;
+import com.flab.readnshare.domain.member.dto.MemberInfoResponseDto;
 import com.flab.readnshare.domain.member.dto.MemberResponseDto;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
@@ -22,13 +24,13 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberApiControllerTest {
@@ -168,6 +170,134 @@ class MemberApiControllerTest {
             // then
             resultActions.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("findById 테스트")
+    class findById {
+        @Test
+        @DisplayName("성공")
+        void success() throws Exception {
+            // given
+            Long memberId = 1L;
+            String email = "test@naver.com";
+            String nickName = "testUser";
+            String profileContent = "신규회원입니다."; // profileContent 값 추가
+            Long profileImage = 1L;
+            String profileImagePath = "https://github.com/sun-zip/read-and-share/blob/develop/.github/readme/parkseonggeun.png";
+
+            Member member = Member.builder()
+                    .id(memberId)
+                    .email(email)
+                    .nickName(nickName)
+                    .profileContent(profileContent)  // profileContent 값 추가
+                    .profileImage(profileImage)
+                    .build();
+
+            Image image = Image.builder()
+                    .id(profileImage)
+                    .profileImagePath(profileImagePath)
+                    .build();
+
+            when(memberService.findById(memberId)).thenReturn(member);
+            when(memberService.findByImageId(profileImage)).thenReturn(image);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get("/api/member/{memberId}", memberId)  // URI 경로에 직접 memberId를 전달
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(memberId))  // memberId 확인
+                    .andExpect(jsonPath("$.email").value(email))  // 이메일 확인
+                    .andExpect(jsonPath("$.nickName").value(nickName))  // 닉네임 확인
+                    .andExpect(jsonPath("$.profileContent").value(profileContent))  // profileContent 확인
+                    .andExpect(jsonPath("$.profileImagePath").value(profileImagePath));  // profileImagePath 확인
+        }
+
+
+        @Test
+        @DisplayName("실패 - 회원이 없음")
+        void fail_memberNotFound() throws Exception {
+            // given
+            Long memberId = 999L;  // 존재하지 않는 memberId
+
+            when(memberService.findById(memberId)).thenThrow(new MemberException.MemberNotFoundException());
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get("/api/member/{memberId}", memberId)
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions.andExpect(status().isNotFound())  // 404 Not Found
+                    .andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."));
+        }
+
+        @Test
+        @DisplayName("실패 - 프로필 이미지가 없음")
+        void fail_profileImageNotFound() throws Exception {
+            // given
+            Long memberId = 1L;
+            String email = "test@naver.com";
+            String nickName = "testUser";
+            String profileContent = "신규회원입니다.";
+            Long profileImage = 1L;
+
+            Member member = Member.builder()
+                    .id(memberId)
+                    .email(email)
+                    .nickName(nickName)
+                    .profileContent(profileContent)
+                    .profileImage(profileImage)
+                    .build();
+
+            when(memberService.findById(memberId)).thenReturn(member);
+            when(memberService.findByImageId(profileImage)).thenReturn(null); // 이미지가 없으면 null 반환
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get("/api/member/{memberId}", memberId)
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions.andExpect(status().isNotFound()); // 404 Not Found
+        }
+
+        @Test
+        @DisplayName("실패 - 프로필 이미지가 없음")
+        void fail_invalidProfileImage() throws Exception {
+            // given
+            Long memberId = 1L;
+            String email = "test@naver.com";
+            String nickName = "testUser";
+            String profileContent = "신규회원입니다.";
+            Long profileImage = 999L;
+
+            Member member = Member.builder()
+                    .id(memberId)
+                    .email(email)
+                    .nickName(nickName)
+                    .profileContent(profileContent)
+                    .profileImage(profileImage)
+                    .build();
+
+            when(memberService.findById(memberId)).thenReturn(member);
+            when(memberService.findByImageId(profileImage)).thenReturn(null); // 이미지가 없으면 null 반환
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    MockMvcRequestBuilders.get("/api/member/{memberId}", memberId)
+                            .contentType(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions.andExpect(status().isNotFound()); // 404 Not Found
         }
     }
 

--- a/src/test/java/com/flab/readnshare/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/member/service/MemberServiceTest.java
@@ -1,9 +1,12 @@
 package com.flab.readnshare.domain.member.service;
 
+import com.flab.readnshare.domain.member.domain.Image;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
+import com.flab.readnshare.domain.member.repository.ImageRepository;
 import com.flab.readnshare.domain.member.repository.MemberRepository;
+import com.flab.readnshare.global.common.exception.ImageException;
 import com.flab.readnshare.global.common.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,14 +30,17 @@ class MemberServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
-    private PasswordEncoder passwordEncoder;  // Ensure this is mocked
+    private ImageRepository imageRepository;  // 추가된 ImageRepository 목 객체
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private MemberService memberService;
 
     @Nested
-    @DisplayName("signUp 테스트")
-    class signUp {
+    @DisplayName("회원가입 테스트")
+    class SignUpTest {
         @Test
         @DisplayName("성공")
         void success() {
@@ -42,37 +48,28 @@ class MemberServiceTest {
             SignUpRequestDto request = SignUpRequestDto.builder()
                     .email("test@naver.com")
                     .password("test24680!")
-                    .nickName("test")
+                    .nickName("testUser")
                     .build();
 
-            // 암호화된 비밀번호를 가상으로 설정
-            String encodedPassword = "encodedNewPassword"; // 가상의 암호화된 비밀번호
-            when(passwordEncoder.encode(request.getPassword())).thenReturn(encodedPassword);
+            when(passwordEncoder.encode(request.getPassword())).thenReturn("encodedPassword");
+            when(memberRepository.findByEmail(request.getEmail())).thenReturn(Optional.empty());
 
-            // 회원이 존재하지 않으므로 Optional.empty()를 반환
-            when(memberRepository.findByEmail(any(String.class))).thenReturn(Optional.empty());
-
-            // expectedMember 생성 시, 암호화된 비밀번호를 사용하여 비교
             Member expectedMember = Member.builder()
                     .email(request.getEmail())
-                    .password(encodedPassword)  // 암호화된 비밀번호 사용
+                    .password("encodedPassword")
                     .nickName(request.getNickName())
                     .build();
 
-            // save()가 호출되면 expectedMember를 반환하도록 설정
             when(memberRepository.save(any(Member.class))).thenReturn(expectedMember);
 
             // when
-            // SignUpRequestDto의 toEntity 호출 시 passwordEncoder를 전달
             Member savedMember = memberService.signUp(request, passwordEncoder);
 
             // then
             assertNotNull(savedMember);
             assertEquals("test@naver.com", savedMember.getEmail());
-            assertEquals(encodedPassword, savedMember.getPassword());  // 암호화된 비밀번호가 맞는지 확인
-            assertEquals("test", savedMember.getNickName());
-
-            // memberRepository의 save()가 한 번 호출되었는지 검증
+            assertEquals("encodedPassword", savedMember.getPassword());
+            assertEquals("testUser", savedMember.getNickName());
             verify(memberRepository, times(1)).save(any(Member.class));
         }
 
@@ -83,55 +80,136 @@ class MemberServiceTest {
             SignUpRequestDto request = SignUpRequestDto.builder()
                     .email("test@naver.com")
                     .password("test24680!")
-                    .nickName("test")
+                    .nickName("testUser")
                     .build();
 
-            Optional<Member> m = Optional.of(mock(Member.class));
-            when(memberRepository.findByEmail(request.getEmail())).thenReturn(m);
+            when(memberRepository.findByEmail(request.getEmail())).thenReturn(Optional.of(mock(Member.class)));
 
             // then
-            assertThrows(MemberException.DuplicateEmailException.class, () -> memberService.signUp(request, passwordEncoder), "이메일이 중복되어 회원가입에 실패해야 합니다.");
+            assertThrows(MemberException.DuplicateEmailException.class,
+                    () -> memberService.signUp(request, passwordEncoder));
         }
     }
 
     @Nested
-    @DisplayName("update 테스트")
-    class update {
+    @DisplayName("회원 정보 수정 테스트")
+    class UpdateTest {
         @Test
         @DisplayName("성공")
         void success() {
-            // given (기존 회원 정보)
+            // given
             Long memberId = 1L;
             Member existingMember = Member.builder()
                     .id(memberId)
-                    .email("test@naver.com")  // 기본 이메일은 수정하지 않음
+                    .email("test@naver.com")
                     .password("oldPassword123!")
                     .nickName("oldNickName")
+                    .profileContent("oldContent")
+                    .profileImage(2L)
                     .build();
 
             UpdateRequestDto request = UpdateRequestDto.builder()
-                    .password("newPassword24680!") // 새로운 비밀번호
-                    .nickName("newNickName")       // 새로운 닉네임
+                    .password("newPassword24680!")
+                    .nickName("newNickName")
+                    .profileContent("newContent")
+                    .profileImage(3L)
                     .build();
 
-            // toEntity()로 비밀번호 암호화된 업데이트된 멤버 생성
-            String encodedPassword = "encodedNewPassword"; // 가상의 암호화된 비밀번호
-            when(passwordEncoder.encode(request.getPassword())).thenReturn(encodedPassword);
-
-            // 기존 회원이 존재하는 경우를 가정
+            when(passwordEncoder.encode(request.getPassword())).thenReturn("encodedNewPassword");
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(existingMember));
 
-            // when (실제 메소드를 호출하여 회원정보 수정)
+            // when
             Member updatedMember = memberService.update(memberId, request, passwordEncoder);
 
-            // then (업데이트된 멤버의 닉네임과 비밀번호가 올바르게 수정되었는지 확인)
+            // then
             assertNotNull(updatedMember);
             assertEquals("newNickName", updatedMember.getNickName());
-            assertEquals(encodedPassword, updatedMember.getPassword());
-            assertEquals("test@naver.com", updatedMember.getEmail()); // 이메일은 수정되지 않아야 함
+            assertEquals("encodedNewPassword", updatedMember.getPassword());
+            assertEquals("newContent", updatedMember.getProfileContent());
+            assertEquals(3L, updatedMember.getProfileImage());
+            assertEquals("test@naver.com", updatedMember.getEmail());
 
-            // memberRepository의 save()가 호출되었는지 검증
-            verify(memberRepository, times(1)).save(updatedMember);
+            verify(memberRepository, times(1)).save(existingMember);
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 조회 테스트")
+    class FindByIdTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Long memberId = 1L;
+            Member member = Member.builder()
+                    .id(memberId)
+                    .email("test@naver.com")
+                    .nickName("testUser")
+                    .build();
+
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+            // when
+            Member foundMember = memberService.findById(memberId);
+
+            // then
+            assertNotNull(foundMember);
+            assertEquals(memberId, foundMember.getId());
+            assertEquals("test@naver.com", foundMember.getEmail());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 회원")
+        void fail_memberNotFound() {
+            // given
+            Long memberId = 999L;
+            when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+            // then
+            assertThrows(MemberException.MemberNotFoundException.class, () -> memberService.findById(memberId));
+        }
+    }
+
+    @Nested
+    @DisplayName("이미지 조회 테스트")
+    class FindByImageIdTest {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Long imageId = 1L;
+            Image image = Image.builder()
+                    .id(imageId)
+                    .profileImagePath("https://image-url.com/image.png")
+                    .build();
+
+            when(imageRepository.findById(imageId)).thenReturn(Optional.of(image));
+
+            // when
+            Image foundImage = memberService.findByImageId(imageId);
+
+            // then
+            assertNotNull(foundImage);
+            assertEquals(imageId, foundImage.getId());
+            assertEquals("https://image-url.com/image.png", foundImage.getProfileImagePath());
+        }
+
+        @Test
+        @DisplayName("실패 - 이미지 ID가 null")
+        void fail_nullImageId() {
+            // then
+            assertThrows(IllegalArgumentException.class, () -> memberService.findByImageId(null));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 이미지 ID")
+        void fail_imageNotFound() {
+            // given
+            Long imageId = 999L;
+            when(imageRepository.findById(imageId)).thenReturn(Optional.empty());
+
+            // then
+            assertThrows(ImageException.NotFoundImageException.class, () -> memberService.findByImageId(imageId));
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #108, #109, #110

## 📝 작업 내용
> 소개글(profileContent) 및 프로필이미지 추가
> 회원 id 조회 시 소개글) 및 프로필이미지 확인 가능
> 회원 수정 시 소개글) 및 프로필이미지 변경 가능
> Image 테이블 추가 (image_id, profile_image_path)
> NotFoundImage 에러코드 추가
> 기존 Member 테이블에 profileImage 추가 (1~4 중에 선택하도록, 기본값 1)
> memberId 조회 시 profileImagePath가 리턴되도록 수정
> 기존 테스트코드 수정
> 부족한 테스트 코드 추가

### 스크린샷 (선택)
![스크린샷 2025-03-21 오후 3 18 23](https://github.com/user-attachments/assets/b27104c6-bb4a-4bc0-a76a-7cfd0a9f6d98)
![스크린샷 2025-03-21 오후 3 18 06](https://github.com/user-attachments/assets/b471f83e-e6e7-4d93-baff-6a31315f645b)
![스크린샷 2025-03-21 오후 4 26 40](https://github.com/user-attachments/assets/438276db-13a2-4890-b07f-95bfec09595b)

## 💬 리뷰 요구사항(선택)
