### PR TITLE
feat: 이메일 인증 관련 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'it.ozimov:embedded-redis:0.7.2'
 
+	// email
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/flab/readnshare/domain/auth/service/AuthService.java
+++ b/src/main/java/com/flab/readnshare/domain/auth/service/AuthService.java
@@ -34,6 +34,9 @@ public class AuthService {
         if(!passwordEncoder.matches(dto.getPassword(), member.getPassword())){
             throw new AuthException.InvalidEmailOrPasswordException();
         }
+        if(!member.isVerified()) {
+            throw new AuthException.UnverifiedEmailException();
+        }
         return member;
     }
 

--- a/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/member/controller/MemberApiController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/member")
+@RequestMapping("/api/v1/members")
 public class MemberApiController {
     private final MemberService memberService;
     private final PasswordEncoder passwordEncoder; // PasswordEncoder 주입
@@ -26,21 +26,28 @@ public class MemberApiController {
     // 회원가입
     @PostMapping("/signUp")
     public ResponseEntity<MemberResponseDto> signUp(@Valid @RequestBody SignUpRequestDto dto){
-        Member newMember = memberService.signUp(dto, passwordEncoder);
+        Member member = memberService.signUp(dto);
 
         MemberResponseDto responseDto = MemberResponseDto.builder()
-                .id(newMember.getId())
-                .email(newMember.getEmail())
-                .nickName(newMember.getNickName())
+                .id(member.getId())
+                .email(member.getEmail())
+                .nickName(member.getNickName())
                 .build();
 
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
     }
 
+    // 이메일 인증
+    @GetMapping("/verify")
+    public ResponseEntity<String> verifyEmail(@RequestParam String token) {
+        memberService.verifyEmail(token);
+        return ResponseEntity.ok("이메일 인증이 완료되었습니다!");
+    }
+
     // 회원수정
     @PutMapping("/{memberId}")
     public ResponseEntity<MemberResponseDto> update(@PathVariable Long memberId, @Valid @RequestBody UpdateRequestDto dto){
-        Member updatedMember = memberService.update(memberId, dto, passwordEncoder);
+        Member updatedMember = memberService.update(memberId, dto);
 
         MemberResponseDto responseDto = MemberResponseDto.builder()
                 .id(updatedMember.getId())

--- a/src/main/java/com/flab/readnshare/domain/member/domain/EmailToken.java
+++ b/src/main/java/com/flab/readnshare/domain/member/domain/EmailToken.java
@@ -1,0 +1,39 @@
+package com.flab.readnshare.domain.member.domain;
+
+import com.flab.readnshare.global.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;  // 인증할 이메일
+    private String token;  // 인증 토큰
+    private LocalDateTime expiryDate; // 만료시간
+
+    @Builder
+    public EmailToken(String email, String token, LocalDateTime expiryDate) {
+        this.email = email;
+        this.token = token;
+        this.expiryDate = expiryDate;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiryDate);
+    }
+}
+

--- a/src/main/java/com/flab/readnshare/domain/member/domain/Member.java
+++ b/src/main/java/com/flab/readnshare/domain/member/domain/Member.java
@@ -22,6 +22,7 @@ public class Member extends BaseTimeEntity {
     private String nickName;
     private String profileContent;
     private Long profileImage;
+    private boolean isVerified;  // 이메일 인증 여부 추가
 
     @PrePersist
     public void setDefaultValues() {
@@ -31,13 +32,14 @@ public class Member extends BaseTimeEntity {
     }
 
     @Builder
-    public Member(Long id, String email, String password, String nickName, String profileContent, Long profileImage) {
+    public Member(Long id, String email, String password, String nickName, String profileContent, Long profileImage, boolean isVerified) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.nickName = nickName;
         this.profileContent = profileContent;
         this.profileImage = profileImage;
+        this.isVerified = isVerified;
     }
 
     // 닉네임, 비밀번호 변경용 updateInfo 추가
@@ -46,6 +48,10 @@ public class Member extends BaseTimeEntity {
         this.password = password;
         this.profileContent = profileContent;
         this.profileImage = profileImage;
+    }
+
+    public void setVerified(boolean verified) {
+        this.isVerified = verified;
     }
 
     @Override

--- a/src/main/java/com/flab/readnshare/domain/member/repository/EmailTokenRepository.java
+++ b/src/main/java/com/flab/readnshare/domain/member/repository/EmailTokenRepository.java
@@ -1,0 +1,12 @@
+package com.flab.readnshare.domain.member.repository;
+
+import com.flab.readnshare.domain.member.domain.EmailToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailTokenRepository extends JpaRepository<EmailToken, Long> {
+    Optional<EmailToken> findByToken(String token);
+    Optional<EmailToken> findByEmail(String email);
+}
+

--- a/src/main/java/com/flab/readnshare/domain/member/service/EmailService.java
+++ b/src/main/java/com/flab/readnshare/domain/member/service/EmailService.java
@@ -1,0 +1,60 @@
+package com.flab.readnshare.domain.member.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.MailException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}") // 발신자 이메일 (application.yml 설정 필요)
+    private String fromEmail;
+
+    public void sendVerificationEmail(String toEmail, String token) throws MessagingException {
+        String subject = "ReadNShare 이메일 인증을 완료해주세요!";
+        String verificationLink = "http://localhost:8080/api/v1/members/verify?token=" + token;
+
+        // HTML 이메일 내용
+        String content = "<html>"
+                + "<body>"
+                + "<h2>이메일 인증을 완료하세요</h2>"
+                + "<p>다음 버튼을 클릭하여 이메일 인증을 완료하세요:</p>"
+                + "<a href='" + verificationLink + "' style='"
+                + "display: inline-block;"
+                + "padding: 10px 20px;"
+                + "background-color: #4CAF50;"
+                + "color: white;"
+                + "text-align: center;"
+                + "text-decoration: none;"
+                + "border-radius: 5px;'>이메일 인증</a>"
+                + "</body>"
+                + "</html>";
+
+        sendEmail(toEmail, subject, content);
+    }
+
+    private void sendEmail(String to, String subject, String content) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true, "UTF-8");  // 인코딩을 UTF-8로 설정
+
+        messageHelper.setFrom(fromEmail);
+        messageHelper.setTo(to);
+        messageHelper.setSubject(subject);
+        messageHelper.setText(content, true);  // true를 설정하면 HTML 이메일로 보냄
+
+        try {
+            mailSender.send(mimeMessage);
+        } catch (MailException e) {
+            e.printStackTrace();
+            throw new MessagingException("이메일 전송에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
+++ b/src/main/java/com/flab/readnshare/domain/member/service/MemberService.java
@@ -1,36 +1,90 @@
 package com.flab.readnshare.domain.member.service;
 
+import com.flab.readnshare.domain.member.domain.EmailToken;
 import com.flab.readnshare.domain.member.domain.Image;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.dto.SignUpRequestDto;
 import com.flab.readnshare.domain.member.dto.UpdateRequestDto;
+import com.flab.readnshare.domain.member.repository.EmailTokenRepository;
 import com.flab.readnshare.domain.member.repository.ImageRepository;
 import com.flab.readnshare.domain.member.repository.MemberRepository;
 import com.flab.readnshare.global.common.exception.ImageException;
 import com.flab.readnshare.global.common.exception.MemberException;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final EmailTokenRepository emailTokenRepository;
+    private final EmailService emailService;
     private final PasswordEncoder passwordEncoder;
     private final ImageRepository imageRepository;
 
-    /**
-     * 회원가입
-     */
+    // 회원가입
     @Transactional
-    public Member signUp(SignUpRequestDto dto, PasswordEncoder passwordEncoder) {
+    public Member signUp(SignUpRequestDto dto) {
         validateDuplicateMember(dto.getEmail());
-        return memberRepository.save(dto.toEntity(passwordEncoder));
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(dto.getPassword());
+
+        // 계정을 비활성화한 상태로 저장
+        Member member = Member.builder()
+                .email(dto.getEmail())
+                .password(encodedPassword)
+                .nickName(dto.getNickName())
+                .isVerified(false)  // 이메일 인증 전까지 비활성화
+                .build();
+
+        memberRepository.save(member);
+
+        // 이메일 인증 토큰 생성 및 저장
+        String token = UUID.randomUUID().toString();
+        EmailToken emailToken = EmailToken.builder()
+                .email(dto.getEmail())
+                .token(token)
+                .expiryDate(LocalDateTime.now().plusHours(24)) // 24시간 유효
+                .build();
+
+        emailTokenRepository.save(emailToken);
+
+        // 이메일 발송
+        try {
+            emailService.sendVerificationEmail(dto.getEmail(), token);
+        } catch (MessagingException e) {
+            // 예외 처리: 예를 들어, 회원가입 실패 처리
+            throw new RuntimeException("이메일 인증 발송에 실패했습니다.", e);
+        }
+        return member;
+    }
+
+    // 이메일 인증
+    @Transactional
+    public void verifyEmail(String token) {
+        EmailToken emailToken = emailTokenRepository.findByToken(token)
+                .orElseThrow(() -> new MemberException.InvalidTokenException());
+
+        if (emailToken.isExpired()) {
+            throw new MemberException.ExpiredTokenException();
+        }
+
+        Member member = memberRepository.findByEmail(emailToken.getEmail())
+                .orElseThrow(MemberException.MemberNotFoundException::new);
+
+        member.setVerified(true); // 계정 활성화
+        memberRepository.save(member);
+
+        emailTokenRepository.delete(emailToken); // 인증 후 토큰 삭제
+
     }
 
     private void validateDuplicateMember(String email) {
@@ -62,7 +116,7 @@ public class MemberService {
 
     // 멤버 수정
     @Transactional
-    public Member update(Long memberId, UpdateRequestDto requestDto, PasswordEncoder passwordEncoder) {
+    public Member update(Long memberId, UpdateRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberException.MemberNotFoundException::new);
 

--- a/src/main/java/com/flab/readnshare/global/common/exception/AuthException.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/AuthException.java
@@ -23,6 +23,12 @@ public class AuthException extends RuntimeException {
         }
     }
 
+    public static class UnverifiedEmailException extends AuthException {
+        public UnverifiedEmailException() {
+            super(ErrorCode.UNVERIFIED_EMAIL);
+        }
+    }
+
     public static class ExpiredTokenException extends AuthException {
         public ExpiredTokenException() {
             super(ErrorCode.JWT_EXPIRED);

--- a/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/ErrorCode.java
@@ -18,12 +18,17 @@ public enum ErrorCode {
     // Image
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미지가 없습니다."),
 
+    // Email
+    INVALID_EMAIL_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 인증 토큰입니다."),
+    EXPIRED_EMAIL_TOKEN(HttpStatus.UNAUTHORIZED, "인증 토큰이 만료되었습니다."),
+
     // Auth
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     JWT_DENIED(HttpStatus.UNAUTHORIZED, "조작되거나 지원되지 않는 토큰입니다."),
     JWT_NULL(HttpStatus.UNAUTHORIZED, "토큰이 없습니다."),
     INVALID_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "이메일 또는 패스워드가 일치하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "이메일 또는 패스워드가 일치하지 않습니다."),
+    UNVERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "인증되지 않은 이메일입니다."),
 
     // Favorite
     FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "즐겨찾기에 등록된 책이 없습니다."),

--- a/src/main/java/com/flab/readnshare/global/common/exception/MemberException.java
+++ b/src/main/java/com/flab/readnshare/global/common/exception/MemberException.java
@@ -23,5 +23,11 @@ public class MemberException extends RuntimeException {
         }
     }
 
+    public static class InvalidTokenException extends MemberException {
+        public InvalidTokenException() { super(ErrorCode.INVALID_EMAIL_TOKEN); }
+    }
 
+    public static class ExpiredTokenException extends MemberException {
+        public ExpiredTokenException() { super(ErrorCode.EXPIRED_EMAIL_TOKEN); }
+    }
 }

--- a/src/main/java/com/flab/readnshare/global/config/EmailConfig.java
+++ b/src/main/java/com/flab/readnshare/global/config/EmailConfig.java
@@ -1,0 +1,28 @@
+package com.flab.readnshare.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername("noreply.readnshare@gmail.com");
+        mailSender.setPassword("ellrjhdhannosjfe");
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/flab/readnshare/global/config/WebMvcConfig.java
+++ b/src/main/java/com/flab/readnshare/global/config/WebMvcConfig.java
@@ -30,7 +30,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addPathPatterns("/**")
 //                 Exclusions for authentication
                 .excludePathPatterns("/signUp", "/signIn", "/api/auth/refresh",
-                        "/api/auth/signIn", "/api/member/signUp",
+                        "/api/auth/signIn", "/api/v1/members/signUp", "/api/v1/members/verify",
                         "/swagger-ui/**", "/v3/api-docs/**","/swagger-resources/**","/error");
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,25 @@ spring:
   config:
     import: optional:file:.env[.properties]
 
+
+  #Email 인증
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: "noreply.readnshare@gmail.com"
+    password: "ellrjhdhannosjfe"
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 1800000  # 30 * 60 * 1000 == 30?
+
 jwt:
   access:
     expiration: 1800000 #30분
@@ -50,8 +69,6 @@ logging:
 firebase:
   service:
     key: /firebase/readnshare-firebase-adminsdk.json
-
-
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #137

## 📝 작업 내용
- 이메일 인증 관련 설정 추가
- 이메일 인증 관련 에러코드 추가
- 회원가입 시 이메일 인증 로직 구현
- 로그인 시 이메일 인증 여부 확인
- member api 호출 uri 변경

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/5907c539-2fab-484c-9f8f-add24e72001b)
![image](https://github.com/user-attachments/assets/a983d344-6aea-4c76-b047-eea6aeb52eab)
![image](https://github.com/user-attachments/assets/ef5c06be-3eb6-4ea1-9369-e4f91ec622ea)


## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요