### PR TITLE
refactor: 리뷰 컨트롤러 URI 접근 방식 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/test/**/build/
 .env
 logs/
+*~
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/flab/readnshare/domain/likeit/controller/LikeItController.java
+++ b/src/main/java/com/flab/readnshare/domain/likeit/controller/LikeItController.java
@@ -2,7 +2,6 @@ package com.flab.readnshare.domain.likeit.controller;
 
 import com.flab.readnshare.domain.likeit.service.LikeItService;
 import com.flab.readnshare.domain.member.domain.Member;
-import com.flab.readnshare.domain.review.controller.uri.ReviewsApiUri;
 import com.flab.readnshare.global.common.resolver.SignInMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping(ReviewsApiUri.BASE)
+@RequestMapping("/api/v1/reviews")
 public class LikeItController {
 
 	private final LikeItService likeItService;

--- a/src/main/java/com/flab/readnshare/domain/review/controller/ReviewApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/review/controller/ReviewApiController.java
@@ -1,7 +1,6 @@
 package com.flab.readnshare.domain.review.controller;
 
 import com.flab.readnshare.domain.member.domain.Member;
-import com.flab.readnshare.domain.review.controller.uri.ReviewsApiUri;
 import com.flab.readnshare.domain.review.dto.ReviewSearchCondition;
 import com.flab.readnshare.domain.review.dto.ReviewSearchResponseDto;
 import com.flab.readnshare.domain.review.dto.SaveReviewRequestDto;
@@ -21,7 +20,7 @@ import java.util.List;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping(ReviewsApiUri.BASE)
+@RequestMapping("/api/v1/reviews")
 public class ReviewApiController {
     private final ReviewService reviewService;
     private final ReviewFacade reviewFacade;

--- a/src/main/java/com/flab/readnshare/domain/review/controller/uri/ReviewsApiUri.java
+++ b/src/main/java/com/flab/readnshare/domain/review/controller/uri/ReviewsApiUri.java
@@ -1,8 +1,0 @@
-package com.flab.readnshare.domain.review.controller.uri;
-
-public class ReviewsApiUri {
-	public static final String BASE = "/api/v1/reviews";
-	public static final String BY_ID = BASE + "/{reviewId}";
-	public static final String LIKE = BY_ID + "/likes";
-
-}

--- a/src/main/java/com/flab/readnshare/domain/review/controller/uri/ReviewsApiUri.java~
+++ b/src/main/java/com/flab/readnshare/domain/review/controller/uri/ReviewsApiUri.java~
@@ -1,8 +1,0 @@
-package com.flab.readnshare.domain.review.controller.uri;
-
-public class ReviewsApiUri {
-	public static final String BASE = "/api/v1/reviews";
-	public static final String BY_ID = BASE + "/{reviewId}";
-	public static final String LIKE = BY_ID + "/like";
-
-}

--- a/src/main/java/com/flab/readnshare/global/common/advice/ApiExceptionAdvice.java
+++ b/src/main/java/com/flab/readnshare/global/common/advice/ApiExceptionAdvice.java
@@ -105,6 +105,7 @@ public class ApiExceptionAdvice {
     public ResponseEntity<Map<String,String>> handleIllegalArgEx(IllegalArgumentException e) {
         return ResponseEntity.badRequest()
                 .body(Map.of("message", e.getMessage()));
+    }
 
     @ExceptionHandler(MissingRequestCookieException.class)
     public ResponseEntity missingRequestCookieExceptionHandler(MissingRequestCookieException ex) {

--- a/src/test/java/com/flab/readnshare/domain/likeit/controller/LikeItControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/likeit/controller/LikeItControllerTest.java
@@ -3,23 +3,21 @@ package com.flab.readnshare.domain.likeit.controller;
 
 import com.flab.readnshare.domain.likeit.service.LikeItService;
 import com.flab.readnshare.domain.member.domain.Member;
-import com.flab.readnshare.domain.review.controller.uri.ReviewsApiUri;
 import com.flab.readnshare.global.common.advice.ApiExceptionAdvice;
 import com.flab.readnshare.global.common.exception.ReviewException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,6 +32,10 @@ public class LikeItControllerTest {
 	private LikeItService likeItService;
 
 	private MockMvc mockMvc;
+
+	public static final String BASE = "/api/v1/reviews";
+	public static final String BY_ID = BASE + "/{reviewId}";
+	public static final String LIKE = BY_ID + "/likes";
 
 	@BeforeEach
 	void setUp(){
@@ -54,7 +56,7 @@ public class LikeItControllerTest {
 			Member mockMember = Member.builder().id(1L).nickName("tester").build();
 
 			// when & then
-			mockMvc.perform(post(ReviewsApiUri.LIKE, reviewId)
+			mockMvc.perform(post(LIKE, reviewId)
 					.requestAttr("signInMember", mockMember))
 					.andExpect(status().isOk());
 
@@ -72,14 +74,12 @@ public class LikeItControllerTest {
 			doThrow(new ReviewException.ReviewNotFoundException())
 					.when(likeItService).toggleLikeIt(eq(reviewId), any(Member.class));
 
-			mockMvc.perform(post(ReviewsApiUri.LIKE, reviewId)
+			mockMvc.perform(post(LIKE, reviewId)
 							.requestAttr("signInMember", mockMember))
 					.andExpect(status().isNotFound())
 					.andExpect(jsonPath("$.message").value("존재하지 않는 독서 기록 입니다."));
 		}
 
-
 	}
-
 
 }

--- a/src/test/java/com/flab/readnshare/domain/review/controller/ReviewApiControllerTest.java
+++ b/src/test/java/com/flab/readnshare/domain/review/controller/ReviewApiControllerTest.java
@@ -3,7 +3,6 @@ package com.flab.readnshare.domain.review.controller;
 import com.flab.readnshare.ReviewTestFixture;
 import com.flab.readnshare.domain.book.dto.BookDto;
 import com.flab.readnshare.domain.member.domain.Member;
-import com.flab.readnshare.domain.review.controller.uri.ReviewsApiUri;
 import com.flab.readnshare.domain.review.domain.Review;
 import com.flab.readnshare.domain.review.dto.ReviewSearchResponseDto;
 import com.flab.readnshare.domain.review.dto.SaveReviewRequestDto;
@@ -51,6 +50,9 @@ class ReviewApiControllerTest {
 
     private MockMvc mockMvc;
 
+    public static final String BASE = "/api/v1/reviews";
+    public static final String BY_ID = BASE + "/{reviewId}";
+
     @BeforeEach
     public void init() {
         mockMvc = MockMvcBuilders
@@ -72,7 +74,7 @@ class ReviewApiControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(
-                    MockMvcRequestBuilders.post(ReviewsApiUri.BASE)
+                    MockMvcRequestBuilders.post(BASE)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new Gson().toJson(request))
             );
@@ -89,7 +91,7 @@ class ReviewApiControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(
-                    MockMvcRequestBuilders.post(ReviewsApiUri.BASE)
+                    MockMvcRequestBuilders.post(BASE)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new Gson().toJson(request))
             );
@@ -110,7 +112,7 @@ class ReviewApiControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(
-                    MockMvcRequestBuilders.post(ReviewsApiUri.BASE)
+                    MockMvcRequestBuilders.post(BASE)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new Gson().toJson(request))
             );
@@ -131,7 +133,7 @@ class ReviewApiControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(
-                    MockMvcRequestBuilders.post(ReviewsApiUri.BASE)
+                    MockMvcRequestBuilders.post(BASE)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new Gson().toJson(request))
             );
@@ -158,7 +160,7 @@ class ReviewApiControllerTest {
 
             // When
             ResultActions resultActions = mockMvc.perform(
-                    delete(ReviewsApiUri.BY_ID, reviewId)
+                    delete(BY_ID, reviewId)
             );
 
             // Then
@@ -175,7 +177,7 @@ class ReviewApiControllerTest {
 
             // When
             ResultActions resultActions = mockMvc.perform(
-                    delete(ReviewsApiUri.BY_ID, reviewId)
+                    delete(BY_ID, reviewId)
             );
 
             // Then
@@ -193,7 +195,7 @@ class ReviewApiControllerTest {
 
             // When
             ResultActions resultActions = mockMvc.perform(
-                    delete(ReviewsApiUri.BY_ID, reviewId)
+                    delete(BY_ID, reviewId)
             );
 
             // Then
@@ -217,7 +219,7 @@ class ReviewApiControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(
-                    MockMvcRequestBuilders.put(ReviewsApiUri.BY_ID, 1L)
+                    MockMvcRequestBuilders.put(BY_ID, 1L)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new Gson().toJson(request))
             );
@@ -237,7 +239,7 @@ class ReviewApiControllerTest {
 
             // When
             ResultActions resultActions = mockMvc.perform(
-                    MockMvcRequestBuilders.put(ReviewsApiUri.BY_ID, 1L)
+                    MockMvcRequestBuilders.put(BY_ID, 1L)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new Gson().toJson(request))
             );
@@ -257,7 +259,7 @@ class ReviewApiControllerTest {
 
             // When
             ResultActions resultActions = mockMvc.perform(
-                    MockMvcRequestBuilders.put(ReviewsApiUri.BY_ID, 1L)
+                    MockMvcRequestBuilders.put(BY_ID, 1L)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new Gson().toJson(request))
             );
@@ -274,7 +276,7 @@ class ReviewApiControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(
-                    MockMvcRequestBuilders.put(ReviewsApiUri.BY_ID, 1L)
+                    MockMvcRequestBuilders.put(BY_ID, 1L)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new Gson().toJson(request))
             );
@@ -309,7 +311,7 @@ class ReviewApiControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(
-                        MockMvcRequestBuilders.get(ReviewsApiUri.BASE)
+                        MockMvcRequestBuilders.get(BASE)
                                 .param("title", title)
                                 .accept(MediaType.APPLICATION_JSON)
                 );
@@ -341,7 +343,7 @@ class ReviewApiControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(
-                        MockMvcRequestBuilders.get(ReviewsApiUri.BASE)
+                        MockMvcRequestBuilders.get(BASE)
                                 .param("author", author)
                                 .accept(MediaType.APPLICATION_JSON)
                 );
@@ -372,7 +374,7 @@ class ReviewApiControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(
-                        MockMvcRequestBuilders.get(ReviewsApiUri.BASE)
+                        MockMvcRequestBuilders.get(BASE)
                                 .param("publisher", publisher)
                                 .accept(MediaType.APPLICATION_JSON)
                 );
@@ -402,7 +404,7 @@ class ReviewApiControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(
-                        MockMvcRequestBuilders.get(ReviewsApiUri.BASE)
+                        MockMvcRequestBuilders.get(BASE)
                                 .param("memberName", memberName)
                                 .accept(MediaType.APPLICATION_JSON)
                 );
@@ -434,7 +436,7 @@ class ReviewApiControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(
-                        MockMvcRequestBuilders.get(ReviewsApiUri.BASE)
+                        MockMvcRequestBuilders.get(BASE)
                                 .param("keyword", keyword)
                                 .contentType(MediaType.APPLICATION_JSON)
                 );
@@ -456,7 +458,7 @@ class ReviewApiControllerTest {
         @Test
         @DisplayName("검색 실패 - 파라미터 없음")
         public void fail_no_param() throws Exception {
-            mockMvc.perform(MockMvcRequestBuilders.get(ReviewsApiUri.BASE))
+            mockMvc.perform(MockMvcRequestBuilders.get(BASE))
 					.andExpect(status().isBadRequest())
 					.andExpect(jsonPath("$.message").value("검색 조건은 하나만 입력해야 합니다."));
 
@@ -467,7 +469,7 @@ class ReviewApiControllerTest {
         @Test
         @DisplayName("검색 실패 - 파라미터 2개 이상")
         void fail_multiple_params() throws Exception {
-            mockMvc.perform(MockMvcRequestBuilders.get(ReviewsApiUri.BASE)
+            mockMvc.perform(MockMvcRequestBuilders.get(BASE)
                             .param("title", "Java")
                             .param("author", "Smith"))
                     .andExpect(status().isBadRequest())


### PR DESCRIPTION
ReviewApiUri 삭제
리뷰컨트롤러에서는 직접 URI로 맵핑
리뷰컨트롤러테스트에서 필드값으로 URI를 선언하여 테스트 전체에서 사용

Resolves: #162

## #️⃣ 연관된 이슈

> #162 

## 📝 작업 내용

> ReviewApiUri 삭제
> 리뷰컨트롤러에서는 직접 URI로 맵핑
> 리뷰컨트롤러테스트에서 필드값으로 URI를 선언하여 테스트 전체에서 사용

### 스크린샷 (선택)

![스크린샷 2025-03-26 102332](https://github.com/user-attachments/assets/87c5a8d0-f418-4e55-87ee-8aaa5dbc7c09)
전체테스트 이상 없음

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
