### PR TITLE
refactor: 리뷰와 좋아요 도메인에 swagger API 문서화 적용

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/likeit/controller/LikeItController.java
+++ b/src/main/java/com/flab/readnshare/domain/likeit/controller/LikeItController.java
@@ -3,6 +3,11 @@ package com.flab.readnshare.domain.likeit.controller;
 import com.flab.readnshare.domain.likeit.service.LikeItService;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.global.common.resolver.SignInMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,12 +18,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reviews")
+@Tag(name = "Like", description = "좋아요")
 public class LikeItController {
 
 	private final LikeItService likeItService;
 
 	@PostMapping("/{reviewId}/likes")
-	public ResponseEntity<Void> toggleLikeIt(@PathVariable Long reviewId, @SignInMember Member signInMember){
+	@Operation(summary = "리뷰 좋아요/취소", description = "리뷰에 좋아요를 누르거나 이미 누른 좋아요를 취소합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "201", description = "리뷰 좋아요/취소 성공"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+			@ApiResponse(responseCode = "404", description = "리뷰 정보 없음")
+	})
+	public ResponseEntity<Void> toggleLikeIt(
+			@Parameter(description = "삭제할 리뷰 ID") @PathVariable Long reviewId,
+			@Parameter(hidden = true) @SignInMember Member signInMember){
 		likeItService.toggleLikeIt(reviewId, signInMember);
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/com/flab/readnshare/domain/review/controller/ReviewApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/review/controller/ReviewApiController.java
@@ -9,9 +9,15 @@ import com.flab.readnshare.domain.review.dto.UpdateReviewRequestDto;
 import com.flab.readnshare.domain.review.facade.ReviewFacade;
 import com.flab.readnshare.domain.review.service.ReviewService;
 import com.flab.readnshare.global.common.resolver.SignInMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,17 +28,32 @@ import java.util.List;
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reviews")
+@Tag(name = "Review", description = "리뷰")
 public class ReviewApiController {
     private final ReviewService reviewService;
     private final ReviewFacade reviewFacade;
 
-    @PostMapping
+	@PostMapping
+	@Operation(summary = "리뷰 등록", description = "리뷰를 등록합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "201", description = "리뷰 등록 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+	})
     public ResponseEntity<Long> save(@Valid @RequestBody SaveReviewRequestDto dto, @SignInMember Member signInMember) {
         Long reviewId = reviewFacade.save(dto, signInMember);
         return new ResponseEntity<>(reviewId, HttpStatus.CREATED);
     }
 
     @PutMapping("/{reviewId}")
+	@Operation(summary = "리뷰 수정", description = "리뷰를 수정합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "리뷰 수정 성공"),
+			@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+			@ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+			@ApiResponse(responseCode = "404", description = "리뷰 정보 없음")
+	})
     public ResponseEntity<Long> update(
             @PathVariable Long reviewId
             , @SignInMember Member signInMember
@@ -41,13 +62,28 @@ public class ReviewApiController {
     }
 
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<Void> delete(@PathVariable Long reviewId, @SignInMember Member signInMember) {
+	@Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "204", description = "리뷰 삭제 성공"),
+			@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+			@ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+			@ApiResponse(responseCode = "404", description = "리뷰 정보 없음")
+	})
+    public ResponseEntity<Void> delete(
+			@Parameter(description = "삭제할 리뷰 ID") @PathVariable Long reviewId,
+			@Parameter(hidden = true) @SignInMember Member signInMember) {
         reviewFacade.delete(reviewId, signInMember);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
 	@GetMapping("/{reviewId}")
-	public ResponseEntity<ReviewSearchResponseDto> findById(@PathVariable Long reviewId) {
+	@Operation(summary = "리뷰 단건 조회", description = "리뷰 ID를 기반으로 리뷰 정보를 조회합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "리뷰 조회 성공"),
+			@ApiResponse(responseCode = "404", description = "리뷰 정보 없음")
+	})
+	public ResponseEntity<ReviewSearchResponseDto> findById(
+			@Parameter(description = "조회할 리뷰 ID") @PathVariable Long reviewId) {
 		Review review = reviewService.findById(reviewId);
 		ReviewSearchResponseDto dto = new ReviewSearchResponseDto(
 				review.getId(),
@@ -61,7 +97,15 @@ public class ReviewApiController {
 	}
 
     @GetMapping
-    public ResponseEntity<List<ReviewSearchResponseDto>> search(@ModelAttribute ReviewSearchCondition condition) {
+	@Operation(
+			summary = "리뷰 검색",
+			description = """
+        등록된 리뷰를 다양한 키워드(책 제목, 저자, 출판사, 작성자 닉네임, 키워드) 중 하나로 검색합니다.
+        ⚠️ 단, 검색 조건은 **하나만** 입력해야 합니다.
+        """
+	)
+    public ResponseEntity<List<ReviewSearchResponseDto>> search(
+			@ParameterObject @ModelAttribute ReviewSearchCondition condition) {
         if (condition.countNonEmpty() != 1) {
             throw new IllegalArgumentException("검색 조건은 하나만 입력해야 합니다.");
         }

--- a/src/main/java/com/flab/readnshare/domain/review/dto/ReviewSearchCondition.java
+++ b/src/main/java/com/flab/readnshare/domain/review/dto/ReviewSearchCondition.java
@@ -1,15 +1,25 @@
 package com.flab.readnshare.domain.review.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
 public class ReviewSearchCondition {
-
+	@Schema(description = "책 제목", example = "스프링 기초")
 	private String title;
+
+	@Schema(description = "책 작가", example = "James Dean")
 	private String author;
+
+	@Schema(description = "출판사", example = "코딩출판")
 	private String publisher;
+
+	@Schema(description = "리뷰 작성자 닉네임", example = "readnshare")
 	private String memberName;
+
+	@Schema(description = "통합 키워드", example = "스프링")
 	private String keyword;
+
 
 	public int countNonEmpty() {
 		int count = 0;

--- a/src/main/java/com/flab/readnshare/domain/review/dto/ReviewSearchResponseDto.java
+++ b/src/main/java/com/flab/readnshare/domain/review/dto/ReviewSearchResponseDto.java
@@ -1,16 +1,28 @@
 package com.flab.readnshare.domain.review.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class ReviewSearchResponseDto {
+	@Schema(description = "리뷰 ID", example = "52")
 	private Long reviewId;
+
+	@Schema(description = "리뷰의 내용", example = "내용이 정말 재밌습니다.")
 	private String content;
+
+	@Schema(description = "리뷰한 책의 제목", example = "스프링 기초")
 	private String bookTitle;
+
+	@Schema(description = "리뷰한 책의 저자", example = "James Dean")
 	private String bookAuthor;
+
+	@Schema(description = "리뷰한 책의 출판사", example = "코딩출판")
 	private String bookPublisher;
+
+	@Schema(description = "리뷰한 회원의 이름", example = "readnshare")
 	private String memberName;
 
 }

--- a/src/main/java/com/flab/readnshare/domain/review/dto/SaveReviewRequestDto.java
+++ b/src/main/java/com/flab/readnshare/domain/review/dto/SaveReviewRequestDto.java
@@ -4,6 +4,7 @@ import com.flab.readnshare.domain.book.domain.Book;
 import com.flab.readnshare.domain.book.dto.BookDto;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.review.domain.Review;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -14,12 +15,16 @@ import lombok.Getter;
 @Getter
 public class SaveReviewRequestDto {
     @NotEmpty(message = "내용을 입력해주세요.")
+    @Schema(description = "리뷰 내용", example = "내용이 정말 재밌습니다.")
     private String content;
+
     @Valid
+    @Schema(description = "리뷰한 책의 정보", implementation = BookDto.class)
     private BookDto book;
 
     @Min(value = 0, message = "별점은 0점 이상이어야 합니다.")
     @Max(value = 10, message = "별점은 10점 이하여야 합니다.")
+    @Schema(description = "리뷰의 별점. 0점 ~ 10점. 별 반개당 1점으로 총 별 다섯개 만점", example = "5")
     private Integer score;
 
     @Builder

--- a/src/main/java/com/flab/readnshare/domain/review/dto/UpdateReviewRequestDto.java
+++ b/src/main/java/com/flab/readnshare/domain/review/dto/UpdateReviewRequestDto.java
@@ -1,5 +1,6 @@
 package com.flab.readnshare.domain.review.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
@@ -11,10 +12,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UpdateReviewRequestDto {
     @NotEmpty(message = "내용을 입력해주세요.")
+    @Schema(description = "수정된 리뷰의 내용")
     private String content;
 
     @Min(value = 0, message = "별점은 0점 이상이어야 합니다.")
     @Max(value = 10, message = "별점은 10점 이하여야 합니다.")
+    @Schema(description = "수정된 리뷰의 별점. 기입하지 않는 경우 기존 별점 유지")
     private Integer score;
 
     @Builder


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #173 

## 📝 작업 내용

> 리뷰와 좋아요 도메인의 Controller와 DTO에 swagger API 문서화 작업 완료

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/9a5b58d4-4c5e-45e4-a230-fa4833b00094)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> swagger는 처음이라 명명법이 제대로 됐는지 확인 부탁드리겠습니다.
