### PR TITLE
refactor: 리프레쉬 토큰 취약점 보완

### DIFF
--- a/src/main/java/com/flab/readnshare/domain/auth/controller/AuthApiController.java
+++ b/src/main/java/com/flab/readnshare/domain/auth/controller/AuthApiController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,10 +43,10 @@ public class AuthApiController {
                     @ExampleObject(name = "아이디 또는 패스워드 에러", value = "{ \"code\": \"INVALID_EMAIL_OR_PASSWORD\", \"message\": \"이메일 또는 패스워드가 일치하지 않습니다.\" }"),
             }))
     })
-    public ResponseEntity<MemberResponseDto> signIn(@RequestBody @Valid SignInRequestDto dto, HttpServletResponse response) {
+    public ResponseEntity<MemberResponseDto> signIn(@RequestBody @Valid SignInRequestDto dto, HttpServletRequest request, HttpServletResponse response) {
         Member member = authService.signIn(dto);
         // access token, refresh token 발급
-        authService.issueTokens(response, member.getId());
+        authService.issueTokens(request, response, member.getId());
         return new ResponseEntity<>(MemberResponseDto.from(member), HttpStatus.OK);
     }
 
@@ -63,7 +64,7 @@ public class AuthApiController {
                             @ExampleObject(name = "형식에 맞지 않는 토큰", value = "{ \"code\": \"JWT_DENIED\", \"message\": \"조작되거나 지원되지 않는 토큰입니다.\" }")
                     }))
     })
-    public ResponseEntity<Void> refresh(@CookieValue(value = "refreshToken") Cookie cookie, HttpServletResponse response) {
+    public ResponseEntity<Void> refresh(@CookieValue(value = "refreshToken") Cookie cookie, HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = extractRefreshTokenFromCookie(cookie);
         Long memberId = extractMemberIdFromToken(refreshToken);
 
@@ -75,7 +76,7 @@ public class AuthApiController {
                 // refresh token 검증 후 access token 재발급
                 authService.validateTokenFromRedis(refreshToken);
                 // access token 재발급 및 리프레쉬 토큰 로테이션
-                authService.updateRefreshToken(response, memberId, refreshToken);
+                authService.updateRefreshToken(request, response, memberId, refreshToken);
                 return new ResponseEntity<>(HttpStatus.OK);
             }
         }

--- a/src/main/java/com/flab/readnshare/domain/auth/domain/RefreshToken.java
+++ b/src/main/java/com/flab/readnshare/domain/auth/domain/RefreshToken.java
@@ -22,14 +22,18 @@ public class RefreshToken {
     // RefreshToken과 연관된 회원의 ID
     private Long memberId;
 
+    // RefreshToken을 발급한 클라이언트의 IP 주소
+    private String ipAddress;
+
     // Redis에서의 만료 시간을 밀리초 단위로 설정
     @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private Long expiration;
 
     @Builder
-    public RefreshToken(String refreshTokenValue, Long memberId, Long expiration) {
+    public RefreshToken(String refreshTokenValue, Long memberId,String ipAddress, Long expiration) {
         this.refreshTokenValue = refreshTokenValue;
         this.memberId = memberId;
+        this.ipAddress = ipAddress;
         this.expiration = expiration;
     }
 }

--- a/src/main/java/com/flab/readnshare/domain/auth/service/AuthService.java
+++ b/src/main/java/com/flab/readnshare/domain/auth/service/AuthService.java
@@ -1,11 +1,13 @@
 package com.flab.readnshare.domain.auth.service;
 
+import com.flab.readnshare.domain.auth.domain.RefreshToken;
 import com.flab.readnshare.domain.auth.dto.SignInRequestDto;
 import com.flab.readnshare.domain.auth.repository.RefreshTokenRepository;
 import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.repository.MemberRepository;
 import com.flab.readnshare.global.common.auth.jwt.JwtUtil;
 import com.flab.readnshare.global.common.exception.AuthException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -49,21 +51,31 @@ public class AuthService {
     }
 
     // memberId에 대한 refresh 토큰을 생성 후 HTTP 응답 쿠키에 설정
-    public void sendRefreshToken(HttpServletResponse response, Long memberId) {
-        String refreshToken = jwtUtil.createRefreshToken(memberId);
+    public void sendRefreshToken(HttpServletRequest request, HttpServletResponse response, Long memberId) {
+        String clientIp = request.getRemoteAddr();
+        String refreshToken = jwtUtil.createRefreshToken(memberId, clientIp);
         jwtUtil.setRefreshTokenCookie(response, refreshToken);
     }
     // memberId에 대한 access, refresh 토큰을 생성 후 HTTP 응답 헤더와 쿠키에 설정
-    public void issueTokens(HttpServletResponse response, Long memberId) {
+    public void issueTokens(HttpServletRequest request, HttpServletResponse response, Long memberId) {
         sendAccessToken(response, memberId);
-        sendRefreshToken(response, memberId);
+        sendRefreshToken(request, response, memberId);
         log.info("AccessToken, RefreshToken 발급 완료 - memberId: {}", memberId);
     }
 
     // refresh 토큰을 삭제하고 새로운 access, refresh 토큰을 발급
-    public void updateRefreshToken(HttpServletResponse response, Long memberId, String oldRefreshToken) {
+    //토큰 재발급 시 클라이언트 IP가 저장된 IP와 일치하는지 검증
+    public void updateRefreshToken(HttpServletRequest request, HttpServletResponse response, Long memberId, String oldRefreshToken) {
+        RefreshToken storedToken = refreshTokenRepository.findById(oldRefreshToken)
+                .orElseThrow(AuthException.ExpiredTokenException::new);
+        String requestIp = request.getRemoteAddr();
+
+        if (!storedToken.getIpAddress().equals(requestIp)) {
+            throw new AuthException.DeniedTokenException();
+        }
+
         refreshTokenRepository.deleteById(oldRefreshToken);
-        issueTokens(response, memberId);
+        issueTokens(request, response, memberId);
     }
 
     // refresh 토큰을 검증

--- a/src/main/java/com/flab/readnshare/global/common/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/flab/readnshare/global/common/auth/jwt/JwtUtil.java
@@ -70,7 +70,7 @@ public class JwtUtil {
      * @param memberId 회원의 ID
      * @return 생성된 리프레시 토큰 문자열
      */
-    public String createRefreshToken(Long memberId) {
+    public String createRefreshToken(Long memberId, String ipAddress) {
         Claims claims = Jwts.claims().setSubject(String.valueOf(memberId));
         Date now = new Date();
 
@@ -85,6 +85,7 @@ public class JwtUtil {
         RefreshToken redisRefreshToken = RefreshToken.builder()
                 .refreshTokenValue(refreshToken)
                 .memberId(memberId)
+                .ipAddress(ipAddress)
                 .expiration(refreshTokenValidTime)
                 .build();
 

--- a/src/test/java/com/flab/readnshare/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/flab/readnshare/domain/auth/service/AuthServiceTest.java
@@ -8,6 +8,7 @@ import com.flab.readnshare.domain.member.domain.Member;
 import com.flab.readnshare.domain.member.repository.MemberRepository;
 import com.flab.readnshare.global.common.auth.jwt.JwtUtil;
 import com.flab.readnshare.global.common.exception.AuthException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -155,24 +156,37 @@ class AuthServiceTest {
             String oldRefreshToken = "oldTokenValue";
             Long memberId = 1L;
             HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+            HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+            // 클라이언트 IP 설정
+            String clientIp = "127.0.0.1";
+            when(request.getRemoteAddr()).thenReturn(clientIp);
+
+            // 저장된 RefreshToken 객체 (클라이언트 IP가 일치하는 경우)
+            RefreshToken storedToken = RefreshToken.builder()
+                    .refreshTokenValue(oldRefreshToken)
+                    .memberId(memberId)
+                    .ipAddress(clientIp)
+                    .expiration(1000000L)
+                    .build();
+            when(refreshTokenRepository.findById(oldRefreshToken)).thenReturn(Optional.of(storedToken));
 
             String newAccessToken = "newAccessToken";
             String newRefreshToken = "newRefreshToken";
 
             when(jwtUtil.createAccessToken(memberId)).thenReturn(newAccessToken);
-            when(jwtUtil.createRefreshToken(memberId)).thenReturn(newRefreshToken);
+            // 수정된 createRefreshToken 메서드는 memberId와 IP 정보를 인자로 받음
+            when(jwtUtil.createRefreshToken(memberId, clientIp)).thenReturn(newRefreshToken);
 
             // when
-            authService.updateRefreshToken(response, memberId, oldRefreshToken);
+            authService.updateRefreshToken(request,response, memberId, oldRefreshToken);
 
             // then
             verify(refreshTokenRepository).deleteById(oldRefreshToken);
             verify(jwtUtil).createAccessToken(memberId);
-            verify(jwtUtil).createRefreshToken(memberId);
+            verify(jwtUtil).createRefreshToken(memberId, clientIp);
             verify(jwtUtil).setAccessTokenHeader(response, newAccessToken);
             verify(jwtUtil).setRefreshTokenCookie(response, newRefreshToken);
-
-
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #177 

## 📝 작업 내용

리프레쉬 토큰에 IP정보를 저장하고 토큰 발급 요청 시 정보가 일치하는 지 확인하는 로직을 추가.

### 스크린샷 
![image](https://github.com/user-attachments/assets/061c1ce6-2c1f-493b-a95d-df149dfa2259)



